### PR TITLE
[Refactor/#9] 사용자 등록/수정 API를 POST와 PATCH로 분리

### DIFF
--- a/src/main/java/org/example/studylog/controller/UserController.java
+++ b/src/main/java/org/example/studylog/controller/UserController.java
@@ -9,9 +9,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.studylog.dto.ProfileCreateRequestDTO;
 import org.example.studylog.dto.ProfileResponseDTO;
+import org.example.studylog.dto.ProfileUpdateRequestDTO;
 import org.example.studylog.dto.UserInfoResponseDTO;
 import org.example.studylog.service.UserService;
 import org.example.studylog.util.ResponseUtil;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,7 +27,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "프로필 업데이트 api", description = "프로필 추가 및 수정을 위한 api")
+    @Operation(summary = "프로필 업데이트 api", description = "프로필 생성을 위한 api")
     @PostMapping("/profile")
     public ResponseEntity<?> createProfile(@Valid @ModelAttribute ProfileCreateRequestDTO request) {
         // 로그인한 사용자 oauthId 가져오기
@@ -34,6 +36,17 @@ public class UserController {
 
         ProfileResponseDTO dto = userService.createUserProfile(request, oauthId);
         return ResponseUtil.buildResponse(200, "사용자 프로필 생성 완료", dto);
+    }
+
+    @Operation(summary = "프로필 수정 api", description = "프로필 수정을 위한 api")
+    @PatchMapping(path = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> updateProfile(@ModelAttribute ProfileUpdateRequestDTO request){
+        // 로그인한 사용자 oauthId 가져오기
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String oauthId = auth.getName();
+
+        ProfileResponseDTO dto = userService.updateUserProfile(request, oauthId);
+        return ResponseUtil.buildResponse(200, "사용자 프로필 수정 완료", dto);
     }
 
     @Operation(summary = "프로필 조회 api")

--- a/src/main/java/org/example/studylog/controller/UserController.java
+++ b/src/main/java/org/example/studylog/controller/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.studylog.dto.ProfileCreateRequestDTO;
@@ -26,7 +27,7 @@ public class UserController {
 
     @Operation(summary = "프로필 업데이트 api", description = "프로필 추가 및 수정을 위한 api")
     @PostMapping("/profile")
-    public ResponseEntity<?> createProfile(@ModelAttribute ProfileCreateRequestDTO request) {
+    public ResponseEntity<?> createProfile(@Valid @ModelAttribute ProfileCreateRequestDTO request) {
         // 로그인한 사용자 oauthId 가져오기
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String oauthId = auth.getName();

--- a/src/main/java/org/example/studylog/controller/UserController.java
+++ b/src/main/java/org/example/studylog/controller/UserController.java
@@ -6,9 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.studylog.dto.ProfileRequestDTO;
+import org.example.studylog.dto.ProfileCreateRequestDTO;
 import org.example.studylog.dto.ProfileResponseDTO;
-import org.example.studylog.dto.ResponseDTO;
 import org.example.studylog.dto.UserInfoResponseDTO;
 import org.example.studylog.service.UserService;
 import org.example.studylog.util.ResponseUtil;
@@ -27,7 +26,7 @@ public class UserController {
 
     @Operation(summary = "프로필 업데이트 api", description = "프로필 추가 및 수정을 위한 api")
     @PostMapping("/profile")
-    public ResponseEntity<?> createProfile(@ModelAttribute ProfileRequestDTO request) {
+    public ResponseEntity<?> createProfile(@ModelAttribute ProfileCreateRequestDTO request) {
         // 로그인한 사용자 oauthId 가져오기
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String oauthId = auth.getName();

--- a/src/main/java/org/example/studylog/controller/UserController.java
+++ b/src/main/java/org/example/studylog/controller/UserController.java
@@ -26,14 +26,14 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "프로필 업데이트 api", description = "프로필 추가 및 수정을 위한 api")
-    @PutMapping("/profile")
-    public ResponseEntity<?> updateProfile(@ModelAttribute ProfileRequestDTO request) {
+    @PostMapping("/profile")
+    public ResponseEntity<?> createProfile(@ModelAttribute ProfileRequestDTO request) {
         // 로그인한 사용자 oauthId 가져오기
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         String oauthId = auth.getName();
 
-        ProfileResponseDTO dto = userService.updateUserProfile(request, oauthId);
-        return ResponseUtil.buildResponse(200, "사용자 프로필 업데이트 완료", dto);
+        ProfileResponseDTO dto = userService.createUserProfile(request, oauthId);
+        return ResponseUtil.buildResponse(200, "사용자 프로필 생성 완료", dto);
     }
 
     @Operation(summary = "프로필 조회 api")

--- a/src/main/java/org/example/studylog/dto/ProfileCreateRequestDTO.java
+++ b/src/main/java/org/example/studylog/dto/ProfileCreateRequestDTO.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
-public class ProfileRequestDTO {
+public class ProfileCreateRequestDTO {
     private MultipartFile profileImage;
     private String nickname;
     private String intro;

--- a/src/main/java/org/example/studylog/dto/ProfileCreateRequestDTO.java
+++ b/src/main/java/org/example/studylog/dto/ProfileCreateRequestDTO.java
@@ -1,5 +1,7 @@
 package org.example.studylog.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
@@ -7,7 +9,10 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Setter
 public class ProfileCreateRequestDTO {
+    @NotNull(message = "사진은 필수입니다.")
     private MultipartFile profileImage;
+    @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;
+    @NotBlank(message = "한줄 소개는 필수입니다.")
     private String intro;
 }

--- a/src/main/java/org/example/studylog/dto/ProfileUpdateRequestDTO.java
+++ b/src/main/java/org/example/studylog/dto/ProfileUpdateRequestDTO.java
@@ -1,0 +1,13 @@
+package org.example.studylog.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class ProfileUpdateRequestDTO {
+    private MultipartFile profileImage;
+    private String nickname;
+    private String intro;
+}

--- a/src/main/java/org/example/studylog/service/UserService.java
+++ b/src/main/java/org/example/studylog/service/UserService.java
@@ -3,6 +3,7 @@ package org.example.studylog.service;
 import lombok.RequiredArgsConstructor;
 import org.example.studylog.dto.ProfileCreateRequestDTO;
 import org.example.studylog.dto.ProfileResponseDTO;
+import org.example.studylog.dto.ProfileUpdateRequestDTO;
 import org.example.studylog.dto.UserInfoResponseDTO;
 import org.example.studylog.entity.user.User;
 import org.example.studylog.repository.FriendRepository;
@@ -39,11 +40,42 @@ public class UserService {
 
         userRepository.save(user);
 
-        // 수정된 데이터로 응답 객체 반환
+        // 생성된 데이터로 응답 객체 반환
         return ProfileResponseDTO.builder()
                 .nickname(user.getNickname())
                 .intro(user.getIntro())
                 .profileImage(imageUrl)
+                .build();
+    }
+
+    @Transactional
+    public ProfileResponseDTO updateUserProfile(ProfileUpdateRequestDTO request, String oauthId) {
+        // 유저 찾기
+        User user = userRepository.findByOauthId(oauthId);
+
+        // 닉네임 수정
+        if(request.getNickname() != null){
+            user.setNickname(request.getNickname());
+        }
+
+        // 한줄 소개 수정
+        if(request.getIntro() != null){
+            user.setIntro(request.getIntro());
+        }
+
+        // 프로필 이미지 수정
+        if(request.getProfileImage() != null){
+            MultipartFile newImage = request.getProfileImage();
+            // S3 업로드
+            String imageUrl = awsS3Service.uploadFile(newImage, user);
+            user.setProfileImage(imageUrl);
+        }
+
+        // 수정된 데이터로 응답 객체 반환
+        return ProfileResponseDTO.builder()
+                .nickname(user.getNickname())
+                .intro(user.getIntro())
+                .profileImage(user.getProfileImage())
                 .build();
     }
 
@@ -77,4 +109,5 @@ public class UserService {
 
         return dto;
     }
+
 }

--- a/src/main/java/org/example/studylog/service/UserService.java
+++ b/src/main/java/org/example/studylog/service/UserService.java
@@ -1,7 +1,7 @@
 package org.example.studylog.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.studylog.dto.ProfileRequestDTO;
+import org.example.studylog.dto.ProfileCreateRequestDTO;
 import org.example.studylog.dto.ProfileResponseDTO;
 import org.example.studylog.dto.UserInfoResponseDTO;
 import org.example.studylog.entity.user.User;
@@ -20,7 +20,7 @@ public class UserService {
     private final FriendRepository friendRepository;
 
     @Transactional
-    public ProfileResponseDTO createUserProfile(ProfileRequestDTO request, String oauthId){
+    public ProfileResponseDTO createUserProfile(ProfileCreateRequestDTO request, String oauthId){
         // 유저 찾기
         User user = userRepository.findByOauthId(oauthId);
 

--- a/src/main/java/org/example/studylog/service/UserService.java
+++ b/src/main/java/org/example/studylog/service/UserService.java
@@ -20,7 +20,7 @@ public class UserService {
     private final FriendRepository friendRepository;
 
     @Transactional
-    public ProfileResponseDTO updateUserProfile(ProfileRequestDTO request, String oauthId){
+    public ProfileResponseDTO createUserProfile(ProfileRequestDTO request, String oauthId){
         // 유저 찾기
         User user = userRepository.findByOauthId(oauthId);
 

--- a/src/test/java/org/example/studylog/controller/UserControllerTest.java
+++ b/src/test/java/org/example/studylog/controller/UserControllerTest.java
@@ -2,7 +2,7 @@ package org.example.studylog.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
-import org.example.studylog.dto.ProfileRequestDTO;
+import org.example.studylog.dto.ProfileCreateRequestDTO;
 import org.example.studylog.dto.ProfileResponseDTO;
 import org.example.studylog.entity.user.User;
 import org.example.studylog.jwt.JWTUtil;
@@ -70,7 +70,7 @@ class UserControllerTest {
                 .profileImage("https://example.com/test.png")
                 .build();
 
-        when(userService.createUserProfile(any(ProfileRequestDTO.class), eq("abc1234")))
+        when(userService.createUserProfile(any(ProfileCreateRequestDTO.class), eq("abc1234")))
                 .thenReturn(dto);
 
         // access 토큰을 쿠키에 담아 요청

--- a/src/test/java/org/example/studylog/controller/UserControllerTest.java
+++ b/src/test/java/org/example/studylog/controller/UserControllerTest.java
@@ -70,7 +70,7 @@ class UserControllerTest {
                 .profileImage("https://example.com/test.png")
                 .build();
 
-        when(userService.updateUserProfile(any(ProfileRequestDTO.class), eq("abc1234")))
+        when(userService.createUserProfile(any(ProfileRequestDTO.class), eq("abc1234")))
                 .thenReturn(dto);
 
         // access 토큰을 쿠키에 담아 요청


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #9 
***
### 💡작업 내용
- POST요청 시 바인딩할 DTO 필드에 검증 로직 추가
- 기존의 유저 정보 업데이트 PUT API를 POST API로 변경
- 유저 정보 수정 시 사용할 PATCH API추가
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
***
### 📚참고 문서(선택)


