### PR TITLE
[Feature/#16] 퀴즈 생성 및 조회 API

### DIFF
--- a/src/main/java/org/example/studylog/client/ChatGptClient.java
+++ b/src/main/java/org/example/studylog/client/ChatGptClient.java
@@ -1,2 +1,14 @@
-package org.example.studylog.client;public class ChatGptClient {
+package org.example.studylog.client;
+
+import org.example.studylog.dto.quiz.chatGPT.ChatGptRequest;
+import org.example.studylog.dto.quiz.chatGPT.ChatGptResponse;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+@HttpExchange("/chat/completions")
+public interface ChatGptClient {
+
+    @PostExchange
+    ChatGptResponse getChatCompletions(@RequestBody ChatGptRequest request);
 }

--- a/src/main/java/org/example/studylog/client/ChatGptClient.java
+++ b/src/main/java/org/example/studylog/client/ChatGptClient.java
@@ -1,0 +1,2 @@
+package org.example.studylog.client;public class ChatGptClient {
+}

--- a/src/main/java/org/example/studylog/config/HttpClientConfig.java
+++ b/src/main/java/org/example/studylog/config/HttpClientConfig.java
@@ -1,0 +1,2 @@
+package org.example.studylog.config;public class HttpClientConfig {
+}

--- a/src/main/java/org/example/studylog/config/HttpClientConfig.java
+++ b/src/main/java/org/example/studylog/config/HttpClientConfig.java
@@ -1,2 +1,30 @@
-package org.example.studylog.config;public class HttpClientConfig {
+package org.example.studylog.config;
+
+import org.example.studylog.client.ChatGptClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class HttpClientConfig {
+
+    @Value("${spring.openai.api-key}")
+    private String apiKey;
+
+    @Bean
+    public ChatGptClient chatGptClient(){
+        RestClient restClient = RestClient.builder()
+                .baseUrl("https://api.openai.com/v1")
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+
+        RestClientAdapter adapter = RestClientAdapter.create(restClient);
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+
+        return factory.createClient(ChatGptClient.class);
+    }
 }

--- a/src/main/java/org/example/studylog/controller/QuizController.java
+++ b/src/main/java/org/example/studylog/controller/QuizController.java
@@ -1,0 +1,2 @@
+package org.example.studylog.controller;public class QuizController {
+}

--- a/src/main/java/org/example/studylog/controller/QuizController.java
+++ b/src/main/java/org/example/studylog/controller/QuizController.java
@@ -1,2 +1,51 @@
-package org.example.studylog.controller;public class QuizController {
+package org.example.studylog.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studylog.dto.oauth.CustomOAuth2User;
+import org.example.studylog.dto.quiz.CreateQuizRequestDTO;
+import org.example.studylog.dto.quiz.QuizResponseDTO;
+import org.example.studylog.dto.studyrecord.CreateStudyRecordResponseDTO;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.exception.BusinessException;
+import org.example.studylog.service.QuizService;
+import org.example.studylog.util.ResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/quizzes")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @PostMapping("/{recordId}")
+    public ResponseEntity<?> createQuiz(
+            @AuthenticationPrincipal CustomOAuth2User currentUser,
+            @PathVariable Long recordId,
+            @Valid @RequestBody CreateQuizRequestDTO requestDTO) {
+
+        try {
+            log.info("퀴즈 생성 요청: 사용자={}, 기록ID={}", currentUser.getName(), recordId);
+
+            List<QuizResponseDTO> list = quizService.createQuiz(currentUser.getName(), recordId, requestDTO);
+            log.info("퀴즈 생성 성공: 기록ID={}", recordId);
+
+            return ResponseUtil.buildResponse(200, "퀴즈 생성 완료", list);
+
+        } catch (BusinessException e) {
+            log.warn("퀴즈 생성 실패 - 잘못된 요청: {}", e.getMessage());
+            return ResponseUtil.buildResponse(400, e.getMessage(), null);
+
+        } catch (Exception e) {
+            log.error("퀴즈 생성 중 오류 발생", e);
+            return ResponseUtil.buildResponse(500, "내부 서버 오류입니다", null);
+        }
+    }
 }

--- a/src/main/java/org/example/studylog/controller/QuizController.java
+++ b/src/main/java/org/example/studylog/controller/QuizController.java
@@ -48,4 +48,22 @@ public class QuizController {
             return ResponseUtil.buildResponse(500, "내부 서버 오류입니다", null);
         }
     }
+
+    @GetMapping("/{quizId}")
+    public ResponseEntity<?> getQuiz(@AuthenticationPrincipal CustomOAuth2User currentUser,
+                                     @PathVariable Long quizId){
+        try {
+            log.info("퀴즈 상세 조회: 사용자={}, 퀴즈ID={}", currentUser.getName(), quizId);
+
+            QuizResponseDTO dto = quizService.getQuiz(currentUser.getName(), quizId);
+
+            return ResponseUtil.buildResponse(200, "퀴즈 상세 조회 완료", dto);
+        } catch (IllegalArgumentException e){
+            log.warn("퀴즈 상세 조회 실패 - 잘못된 요청: {}", e.getMessage());
+            return ResponseUtil.buildResponse(400, e.getMessage(), null);
+        } catch (Exception e) {
+            log.error("퀴즈 생성 중 오류 발생", e);
+            return ResponseUtil.buildResponse(500, "내부 서버 오류입니다", null);
+        }
+    }
 }

--- a/src/main/java/org/example/studylog/controller/QuizController.java
+++ b/src/main/java/org/example/studylog/controller/QuizController.java
@@ -1,5 +1,6 @@
 package org.example.studylog.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ public class QuizController {
 
     private final QuizService quizService;
 
+    @Operation(summary = "퀴즈 생성", description = "recordId로 친구 생성 API")
     @PostMapping("/{recordId}")
     public ResponseEntity<?> createQuiz(
             @AuthenticationPrincipal CustomOAuth2User currentUser,
@@ -49,6 +51,7 @@ public class QuizController {
         }
     }
 
+    @Operation(summary = "퀴즈 상세 조회", description = "quizId로 퀴즈 상세 조회 API")
     @GetMapping("/{quizId}")
     public ResponseEntity<?> getQuiz(@AuthenticationPrincipal CustomOAuth2User currentUser,
                                      @PathVariable Long quizId){

--- a/src/main/java/org/example/studylog/dto/CategoryDTO.java
+++ b/src/main/java/org/example/studylog/dto/CategoryDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.studylog.entity.category.Category;
 
 @Getter
 @Builder
@@ -13,4 +14,12 @@ public class CategoryDTO {
     private Long id;
     private String name;
     private String color;
+
+    public static CategoryDTO from(Category category){
+        return CategoryDTO.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .color(String.valueOf(category.getColor()))
+                .build();
+    }
 }

--- a/src/main/java/org/example/studylog/dto/quiz/CreateQuizRequestDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/CreateQuizRequestDTO.java
@@ -1,2 +1,21 @@
-package org.example.studylog.dto.quiz;public class CreateQuizRequestDTO {
+package org.example.studylog.dto.quiz;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.example.studylog.entity.quiz.QuizLevel;
+
+@Getter
+@Setter
+public class CreateQuizRequestDTO {
+
+    @NotNull(message = "난이도는 필수입니다")
+    private QuizLevel level;
+
+    @Min(value = 1, message = "퀴즈 갯수는 1 이상이어야 합니다")
+    private int quizCount;
+
+    private String requirement;
 }

--- a/src/main/java/org/example/studylog/dto/quiz/CreateQuizRequestDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/CreateQuizRequestDTO.java
@@ -1,0 +1,2 @@
+package org.example.studylog.dto.quiz;public class CreateQuizRequestDTO {
+}

--- a/src/main/java/org/example/studylog/dto/quiz/QuizListResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/QuizListResponseDTO.java
@@ -1,2 +1,19 @@
-package org.example.studylog.dto.quiz;public class QuizListResponseDTO {
+package org.example.studylog.dto.quiz;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.example.studylog.dto.CategoryDTO;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class QuizListResponseDTO {
+
+    private List<CategoryDTO> categories;
+    private List<QuizSummaryDTO> quizzes;
+    private boolean hasNext;
+    private Long lastId;
 }

--- a/src/main/java/org/example/studylog/dto/quiz/QuizListResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/QuizListResponseDTO.java
@@ -1,0 +1,2 @@
+package org.example.studylog.dto.quiz;public class QuizListResponseDTO {
+}

--- a/src/main/java/org/example/studylog/dto/quiz/QuizResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/QuizResponseDTO.java
@@ -1,11 +1,17 @@
 package org.example.studylog.dto.quiz;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.example.studylog.dto.CategoryDTO;
+import org.example.studylog.entity.category.Category;
+import org.example.studylog.entity.quiz.Quiz;
+
+import java.time.format.DateTimeFormatter;
 
 @Setter
 @Getter
+@Builder
 public class QuizResponseDTO {
 
     private String createdAt;
@@ -15,4 +21,21 @@ public class QuizResponseDTO {
     private String answer;
     private String level;
     private Long recordId;
+
+    public static QuizResponseDTO from(Quiz quiz, Category category){
+
+        return QuizResponseDTO.builder()
+                .createdAt(quiz.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .type(String.valueOf(quiz.getType()))
+                .category(CategoryDTO.builder()
+                        .id(category.getId())
+                        .name(category.getName())
+                        .color(String.valueOf(category.getColor()))
+                        .build())
+                .question(quiz.getQuestion())
+                .answer(quiz.getAnswer())
+                .level(quiz.getLevel().getLabel())
+                .recordId(quiz.getRecord().getId())
+                .build();
+    }
 }

--- a/src/main/java/org/example/studylog/dto/quiz/QuizResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/QuizResponseDTO.java
@@ -1,2 +1,18 @@
-package org.example.studylog.dto.quiz;public class QuizResponseDTO {
+package org.example.studylog.dto.quiz;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.example.studylog.dto.CategoryDTO;
+
+@Setter
+@Getter
+public class QuizResponseDTO {
+
+    private String createdAt;
+    private String type;
+    private CategoryDTO category;
+    private String question;
+    private String answer;
+    private String level;
+    private Long recordId;
 }

--- a/src/main/java/org/example/studylog/dto/quiz/QuizResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/QuizResponseDTO.java
@@ -1,0 +1,2 @@
+package org.example.studylog.dto.quiz;public class QuizResponseDTO {
+}

--- a/src/main/java/org/example/studylog/dto/quiz/QuizSummaryDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/QuizSummaryDTO.java
@@ -1,2 +1,27 @@
-package org.example.studylog.dto.quiz;public class QuizSummaryDTO {
+package org.example.studylog.dto.quiz;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.example.studylog.entity.quiz.Quiz;
+
+@Getter
+@Setter
+@Builder
+public class QuizSummaryDTO {
+    private Long id;
+    private String category;
+    private String color;
+    private String question;
+    private String level;
+
+    public static QuizSummaryDTO from(Quiz quiz) {
+        return QuizSummaryDTO.builder()
+                .id(quiz.getId())
+                .category(quiz.getCategory().getName())
+                .color(String.valueOf(quiz.getCategory().getColor()))
+                .question(quiz.getQuestion())
+                .level(quiz.getLevel().getLabel())
+                .build();
+    }
 }

--- a/src/main/java/org/example/studylog/dto/quiz/QuizSummaryDTO.java
+++ b/src/main/java/org/example/studylog/dto/quiz/QuizSummaryDTO.java
@@ -1,0 +1,2 @@
+package org.example.studylog.dto.quiz;public class QuizSummaryDTO {
+}

--- a/src/main/java/org/example/studylog/dto/quiz/chatGPT/ChatGptRequest.java
+++ b/src/main/java/org/example/studylog/dto/quiz/chatGPT/ChatGptRequest.java
@@ -4,14 +4,22 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChatGptRequestDTO {
+public class ChatGptRequest {
 
     private String model = "gpt-3.5-turbo";
     private List<Message> messages;
     private double temperature = 0.7;
 
-    
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Message {
+        private String role; // "user"
+        private String content;
+    }
 }

--- a/src/main/java/org/example/studylog/dto/quiz/chatGPT/ChatGptRequest.java
+++ b/src/main/java/org/example/studylog/dto/quiz/chatGPT/ChatGptRequest.java
@@ -1,0 +1,17 @@
+package org.example.studylog.dto.quiz.chatGPT;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatGptRequestDTO {
+
+    private String model = "gpt-3.5-turbo";
+    private List<Message> messages;
+    private double temperature = 0.7;
+
+    
+}

--- a/src/main/java/org/example/studylog/dto/quiz/chatGPT/ChatGptResponse.java
+++ b/src/main/java/org/example/studylog/dto/quiz/chatGPT/ChatGptResponse.java
@@ -1,0 +1,25 @@
+package org.example.studylog.dto.quiz.chatGPT;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ChatGptResponse {
+
+    private List<Choice> choices;
+
+    @Data
+    public static class Choice {
+        private Message message;
+    }
+
+    @Data
+    public static class Message {
+        private String role;
+        private String content;
+    }
+}

--- a/src/main/java/org/example/studylog/entity/quiz/Quiz.java
+++ b/src/main/java/org/example/studylog/entity/quiz/Quiz.java
@@ -11,6 +11,8 @@ import org.example.studylog.entity.StudyRecord;
 import org.example.studylog.entity.category.Category;
 import org.example.studylog.entity.user.User;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @SuperBuilder
@@ -36,6 +38,9 @@ public class Quiz extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private QuizType type;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "record_id", nullable = false)

--- a/src/main/java/org/example/studylog/entity/quiz/QuizLevel.java
+++ b/src/main/java/org/example/studylog/entity/quiz/QuizLevel.java
@@ -1,7 +1,23 @@
 package org.example.studylog.entity.quiz;
 
+import lombok.Getter;
+
+@Getter
 public enum QuizLevel {
-    EASY,
-    MEDIUM,
-    HARD
+    EASY("하"),
+    MEDIUM("중"),
+    HARD("상");
+
+    private final String label;
+
+    QuizLevel(String label){
+        this.label = label;
+    }
+
+    public static QuizLevel fromLabel(String label){
+        for (QuizLevel level : values()){
+            if(level.label.equals(label)) return level;
+        }
+        throw new IllegalArgumentException("유효하지 않은 난이도입니다.");
+    }
 }

--- a/src/main/java/org/example/studylog/exception/ErrorCode.java
+++ b/src/main/java/org/example/studylog/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     FRIEND_NOT_FOUND(404, "해당하는 친구가 없습니다."),
     SELF_LOOKUP_NOT_ALLOWED(400, "자기 자신은 조회할 수 없습니다."),
     NOTIFICATION_CONNECTION_ERROR(500, "알림 서버와 연결이 실패하였습니다."),
-    ;
+    STUDY_RECORD_NOT_FOUND(404, "기록이 존재하지 않습니다."),
+    QUIZ_ALREADY_EXISTS(400, "이미 퀴즈가 생성된 기록입니다.");
 
     private int status;
     private final String message;

--- a/src/main/java/org/example/studylog/repository/QuizRepository.java
+++ b/src/main/java/org/example/studylog/repository/QuizRepository.java
@@ -1,2 +1,8 @@
-package org.example.studylog.repository;public interface QuizRepository {
+package org.example.studylog.repository;
+
+import org.example.studylog.entity.quiz.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
 }

--- a/src/main/java/org/example/studylog/repository/QuizRepository.java
+++ b/src/main/java/org/example/studylog/repository/QuizRepository.java
@@ -1,8 +1,9 @@
 package org.example.studylog.repository;
 
 import org.example.studylog.entity.quiz.Quiz;
+import org.example.studylog.repository.custom.QuizRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
-public interface QuizRepository extends JpaRepository<Quiz, Long> {
+public interface QuizRepository extends JpaRepository<Quiz, Long>, QuizRepositoryCustom {
 }

--- a/src/main/java/org/example/studylog/repository/QuizRepository.java
+++ b/src/main/java/org/example/studylog/repository/QuizRepository.java
@@ -1,0 +1,2 @@
+package org.example.studylog.repository;public interface QuizRepository {
+}

--- a/src/main/java/org/example/studylog/repository/custom/QuizRepositoryCustom.java
+++ b/src/main/java/org/example/studylog/repository/custom/QuizRepositoryCustom.java
@@ -1,0 +1,4 @@
+package org.example.studylog.repository.custom;
+
+public interface getQuizList {
+}

--- a/src/main/java/org/example/studylog/repository/custom/QuizRepositoryCustom.java
+++ b/src/main/java/org/example/studylog/repository/custom/QuizRepositoryCustom.java
@@ -1,4 +1,10 @@
 package org.example.studylog.repository.custom;
 
-public interface getQuizList {
+import org.example.studylog.entity.quiz.Quiz;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface QuizRepositoryCustom {
+    List<Quiz> findQuizzes(Long userId, Long lastId, int size, LocalDate date, Long categoryId, String query);
 }

--- a/src/main/java/org/example/studylog/repository/custom/QuizRepositoryImpl.java
+++ b/src/main/java/org/example/studylog/repository/custom/QuizRepositoryImpl.java
@@ -1,2 +1,54 @@
-package org.example.studylog.repository.custom;public class QuizRepositoryImpl {
+package org.example.studylog.repository.custom;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.studylog.entity.category.QCategory;
+import org.example.studylog.entity.quiz.QQuiz;
+import org.example.studylog.entity.quiz.Quiz;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class QuizRepositoryImpl implements QuizRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Quiz> findQuizzes(Long userId, Long lastId, int size, LocalDate date, Long categoryId, String query) {
+
+        QQuiz quiz = QQuiz.quiz;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(quiz.user.id.eq(userId));
+
+        if (lastId != null){
+            builder.and(quiz.id.lt(lastId));
+        }
+
+        if (date != null){
+            builder.and(quiz.createdAt.between(
+                    date.atStartOfDay(),
+                    date.plusDays(1).atStartOfDay()
+            ));
+        }
+
+        if (categoryId != null){
+            builder.and(quiz.category.id.eq(categoryId));
+        }
+
+        if (query != null && !query.isBlank()) {
+            builder.and(
+                    quiz.question.containsIgnoreCase(query));
+        }
+
+        return queryFactory.selectFrom(quiz)
+                .join(quiz.category, QCategory.category).fetchJoin()
+                .where(builder)
+                .orderBy(quiz.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
 }

--- a/src/main/java/org/example/studylog/repository/custom/QuizRepositoryImpl.java
+++ b/src/main/java/org/example/studylog/repository/custom/QuizRepositoryImpl.java
@@ -1,0 +1,2 @@
+package org.example.studylog.repository.custom;public class QuizRepositoryImpl {
+}

--- a/src/main/java/org/example/studylog/service/QuizService.java
+++ b/src/main/java/org/example/studylog/service/QuizService.java
@@ -1,2 +1,173 @@
-package org.example.studylog.service;public class QuizService {
+package org.example.studylog.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.RequiredArgsConstructor;
+import org.example.studylog.client.ChatGptClient;
+import org.example.studylog.dto.CategoryDTO;
+import org.example.studylog.dto.quiz.CreateQuizRequestDTO;
+import org.example.studylog.dto.quiz.QuizResponseDTO;
+import org.example.studylog.dto.quiz.chatGPT.ChatGptRequest;
+import org.example.studylog.dto.quiz.chatGPT.ChatGptResponse;
+import org.example.studylog.entity.StudyRecord;
+import org.example.studylog.entity.category.Category;
+import org.example.studylog.entity.quiz.Quiz;
+import org.example.studylog.entity.quiz.QuizLevel;
+import org.example.studylog.entity.quiz.QuizType;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.exception.BusinessException;
+import org.example.studylog.exception.ErrorCode;
+import org.example.studylog.repository.QuizRepository;
+import org.example.studylog.repository.StudyRecordRepository;
+import org.example.studylog.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    private final StudyRecordRepository studyRecordRepository;
+    private final UserRepository userRepository;
+    private final QuizRepository quizRepository;
+
+    private final ChatGptClient chatGptClient;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public List<QuizResponseDTO> createQuiz(String oauthId, Long recordId, CreateQuizRequestDTO requestDTO) {
+        // 유저 조회
+        User user = userRepository.findByOauthId(oauthId);
+
+        // 퀴즈를 만들 기록 조회
+        StudyRecord studyRecord = studyRecordRepository.findById(recordId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_RECORD_NOT_FOUND));
+        // 이미 퀴즈가 있는 기록이면 에러 반환
+//        if(studyRecord.isQuizCreated())
+//            throw new BusinessException(ErrorCode.QUIZ_ALREADY_EXISTS);
+        if (Boolean.TRUE.equals(studyRecord.isQuizCreated())) {
+            throw new BusinessException(ErrorCode.QUIZ_ALREADY_EXISTS);
+        }
+
+        // 기록에 대한 카테고리 조회 (추후 데이터 반환 시 필요함)
+        Category category = studyRecord.getCategory();
+
+        // 프롬프트 생성
+        String prompt = buildPrompt(requestDTO, studyRecord.getContent());
+
+        // GPT에게 보낼 요청 생성
+        ChatGptRequest request = new ChatGptRequest(
+                "gpt-3.5-turbo",
+                List.of(new ChatGptRequest.Message("user", prompt)),
+                0.7
+        );
+
+        // GPT에게 요청 보내고 응답 받기
+        ChatGptResponse response = chatGptClient.getChatCompletions(request);
+        String json = response.getChoices().get(0).getMessage().getContent();
+
+        // 응답 받은 문자열을 키-값 쌍으로 파싱
+        List<Map<String, String>> quizList;
+        try {
+            quizList = objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("퀴즈 파싱 실패: " + json, e);
+        }
+
+        // 퀴즈 목록을 DB에 저장
+        List<Quiz> quizzes = quizList.stream().map(map -> {
+            Quiz q = new Quiz();
+            q.setQuestion(map.get("question"));
+            q.setAnswer(map.get("answer"));
+            q.setLevel(QuizLevel.fromLabel(map.get("level")));
+            q.setType(QuizType.valueOf(map.get("type")));
+            q.setCreatedAt(studyRecord.getCreateDate());
+            q.setRecord(studyRecord);
+            q.setUser(user);
+            q.setCategory(studyRecord.getCategory());
+            return q;
+        }).toList();
+
+        quizRepository.saveAll(quizzes);
+
+        // 퀴즈 생성되었으니 '기록'의 isQuizCreated를 true로 설정
+        studyRecord.setQuizCreated(true);
+
+        // 응답 데이터 생성
+        List<QuizResponseDTO> quizResponseList = quizzes.stream().map(map -> {
+            QuizResponseDTO dto = new QuizResponseDTO();
+            dto.setCreatedAt(map.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+            dto.setType(String.valueOf(map.getType()));
+            dto.setCategory(CategoryDTO.builder()
+                    .id(category.getId())
+                    .name(category.getName())
+                    .color(String.valueOf(category.getColor()))
+                    .build());
+            dto.setQuestion(map.getQuestion());
+            dto.setAnswer(map.getAnswer());
+            dto.setLevel(map.getLevel().getLabel());
+            dto.setRecordId(map.getRecord().getId());
+            return dto;
+        }).toList();
+
+        return quizResponseList;
+    }
+
+    private String buildPrompt(CreateQuizRequestDTO dto, String content){
+        return String.format("""
+                        너는 퀴즈 생성 도우미야. 아래 내용을 바탕으로 퀴즈를 만들어줘.
+                                        
+                        생성 조건
+                        - 주제: %s
+                        - 난이도: %s
+                        - 개수: %d개
+                        - 문제 유형: OX 또는 단답형 중에서 무작위로 섞어서 생성해줘.
+                        %s
+                                        
+                        참고사항은 문제 유형보다 **우선되는 강력한 조건**이야. 예를 들어 "단답형으로만 생성"이라는 참고사항이 있다면, 문제 유형은 무조건 단답형이여야 해.
+                                        
+                        출력 형식은 JSON 배열로 다음 구조를 따라줘. `type`은 반드시 대문자로 작성해.
+                                        
+                        📌 난이도별 문제 생성 기준 (매우 중요 — 반드시 따를 것):
+                           - 하: 기초 정의, 용어 설명, 개념 암기 문제 (ex. "~이란?", "~의 정의는?")
+                           - 중: 개념 응용, 사례 분석, 실제 사용 예를 묻는 문제 (ex. "~을 언제 사용하나요?", "예시 중 올바른 것을 고르세요")
+                           - 상: 비교, 한계, 내부 동작 원리, 예외 상황 등 심화 개념을 묻는 문제 (ex. "~와 ~의 차이는?", "왜 ~한가요?", "다음 중 틀린 설명은?")
+                                
+                           → 난이도에 따라 문제의 **내용 자체가 달라야 하며**, 단순히 문장 표현만 다르게 만들면 안 된다.
+                           → 난이도가 높을수록 더 깊은 이해가 필요한 질문이 되도록 구성하라.
+                           → 동일한 내용을 표현만 다르게 반복하지 마. 각 난이도별로 주제의 다른 측면을 다뤄야 해.
+                        [
+                          {
+                            "question": "...",
+                            "answer": "...",
+                            "type": "OX" 또는 "SHORT_ANSWER",
+                            "level": 내가 제시한 난이도 그대로
+                          }
+                        ]
+                                        
+                        반드시 지켜야 할 작성 규칙
+                        - question에는 절대 문제 유형(O/X 등)을 포함하지 마. 단순한 문제 내용만 적어.
+                          ❌ 예: "다음 설명이 맞으면 O, 틀리면 X를 고르시오."
+                          ❌ 예: "스프링 빈은 ~이다. (O/X)"
+                          ✅ 예: "스프링 빈이란?"
+                        - answer에는 정확한 정답을 적어. OX의 경우 "O" 또는 "X"로, 단답형은 문장이나 단어로 답변해.
+                        - level은 내가 준 난이도를 그대로 넣어 (예: "하", "중", "상").
+                        - SHORT_ANSWER 유형의 answer는 반드시 20자 이내로 작성해야 해. (한 줄 요약 형태)
+                          예: "빈은 스프링이 관리하는 객체"
+                          ❌ 예: "XML 설정 파일, 자바 기반 설정 클래스..."
+                        - 단답형은 '무엇인가요?', '이유는?', '용도는?' 등 간결한 질문으로 구성해.
+                        - "나열해보세요", "설명하세요", "작성해보세요" 같은 표현은 사용하지 마. (긴 답변 유도 금지)
+                                        
+                        출력은 JSON 배열로만 응답해. 설명이나 여는 말 없이 JSON만 반환해줘.
+                """,
+                content,
+                dto.getLevel().getLabel(),
+                dto.getQuizCount(),
+                dto.getRequirement() != null ? "- 참고사항: " + dto.getRequirement() : ""
+        );
+    }
 }

--- a/src/main/java/org/example/studylog/service/QuizService.java
+++ b/src/main/java/org/example/studylog/service/QuizService.java
@@ -3,7 +3,6 @@ package org.example.studylog.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.RequiredArgsConstructor;
 import org.example.studylog.client.ChatGptClient;
-import org.example.studylog.dto.CategoryDTO;
 import org.example.studylog.dto.quiz.CreateQuizRequestDTO;
 import org.example.studylog.dto.quiz.QuizResponseDTO;
 import org.example.studylog.dto.quiz.chatGPT.ChatGptRequest;
@@ -23,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/org/example/studylog/service/QuizService.java
+++ b/src/main/java/org/example/studylog/service/QuizService.java
@@ -1,0 +1,2 @@
+package org.example.studylog.service;public class QuizService {
+}


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #16 
***
### 💡작업 내용
- ChatGPT API를 활용한 기록에 대한 퀴즈 생성 기능
- 퀴즈 상세 조회 기능
- 퀴즈 목록 조회 기능
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- HTTP Interface로 ChatGPT API 호출
- QueryDsl로 필터링 조건에 맞게 쿼리 생성
- fetchJoin()으로 N+1 문제 해결
***
### 📚참고 문서(선택)


