### PR TITLE
Feature/#11 record api

### DIFF
--- a/src/main/java/org/example/studylog/controller/LoginController.java
+++ b/src/main/java/org/example/studylog/controller/LoginController.java
@@ -12,11 +12,12 @@ public class LoginController {
         return "index.html";
     }
 
-    @GetMapping("/main")
-    @ResponseBody
-    public String main() {
-        return "메인 페이지";
-    }
+    // 메인 페이지 구현에 따라 주석 처리 - 채민
+//    @GetMapping("/main")
+//    @ResponseBody
+//    public String main() {
+//        return "메인 페이지";
+//    }
 
     @GetMapping("/success")
     @ResponseBody

--- a/src/main/java/org/example/studylog/controller/MainController.java
+++ b/src/main/java/org/example/studylog/controller/MainController.java
@@ -1,0 +1,45 @@
+package org.example.studylog.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studylog.dto.oauth.CustomOAuth2User;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.repository.UserRepository;
+import org.example.studylog.service.MainService;
+import org.example.studylog.util.ResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class MainController {
+
+    private final MainService mainService;
+    private final UserRepository userRepository;
+
+    @GetMapping("/main")
+    public ResponseEntity<?> getMainPage(@AuthenticationPrincipal CustomOAuth2User currentUser) {
+        try {
+            log.info("메인 페이지 조회 요청: 사용자={}", currentUser.getName());
+
+            User user = userRepository.findByOauthId(currentUser.getName());
+            if (user == null) {
+                return ResponseUtil.buildResponse(401, "접근 권한이 없습니다.", false);
+            }
+
+            // MainService에서 메인 페이지 데이터를 조회
+            Object mainPageData = mainService.getMainPageData(user);
+
+            log.info("메인 페이지 조회 성공: 사용자={}", currentUser.getName());
+
+            return ResponseUtil.buildResponse(200, "메인 페이지 조회에 성공하였습니다.", mainPageData);
+
+        } catch (Exception e) {
+            log.error("메인 페이지 조회 중 오류 발생", e);
+            return ResponseUtil.buildResponse(500, "내부 서버 오류입니다. 다시 접속해주세요.", null);
+        }
+    }
+}

--- a/src/main/java/org/example/studylog/controller/StreakController.java
+++ b/src/main/java/org/example/studylog/controller/StreakController.java
@@ -1,0 +1,84 @@
+package org.example.studylog.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studylog.dto.oauth.CustomOAuth2User;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.repository.UserRepository;
+import org.example.studylog.service.StreakService;
+import org.example.studylog.util.ResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class StreakController {
+
+    private final StreakService streakService;
+    private final UserRepository userRepository;
+
+    @GetMapping("/streak")
+    public ResponseEntity<?> getMonthlyStreak(
+            @AuthenticationPrincipal CustomOAuth2User currentUser,
+            @RequestParam("year") String year,
+            @RequestParam("month") String month) {
+
+        try {
+            log.info("월별 스트릭 조회 요청: 사용자={}, year={}, month={}",
+                    currentUser.getName(), year, month);
+
+            User user = userRepository.findByOauthId(currentUser.getName());
+            if (user == null) {
+                return ResponseUtil.buildResponse(401, "접근 권한이 없습니다.", false);
+            }
+
+            // 년월 유효성 검증
+            validateYearMonth(year, month);
+
+            // 월별 스트릭 데이터 조회
+            Object monthlyStreakData = streakService.getMonthlyStreakData(user, year, month);
+
+            log.info("월별 스트릭 조회 성공: 사용자={}, year={}, month={}",
+                    currentUser.getName(), year, month);
+
+            return ResponseUtil.buildResponse(200, "스트릭 조회에 성공하였습니다.", monthlyStreakData);
+
+        } catch (IllegalArgumentException e) {
+            log.warn("월별 스트릭 조회 실패 - 잘못된 요청: {}", e.getMessage());
+            return ResponseUtil.buildResponse(400, "잘못된 접근입니다",
+                    Map.of("example", e.getMessage()));
+
+        } catch (Exception e) {
+            log.error("월별 스트릭 조회 중 오류 발생", e);
+            return ResponseUtil.buildResponse(500, "내부 서버 오류입니다. 다시 접속해주세요.", null);
+        }
+    }
+
+    private void validateYearMonth(String year, String month) {
+        // 년도 검증
+        try {
+            int yearInt = Integer.parseInt(year);
+            if (yearInt < 2020 || yearInt > 2030) {
+                throw new IllegalArgumentException("올바르지 않은 년도입니다");
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("올바르지 않은 년도 형식입니다");
+        }
+
+        // 월 검증
+        try {
+            int monthInt = Integer.parseInt(month);
+            if (monthInt < 1 || monthInt > 12) {
+                throw new IllegalArgumentException("올바르지 않은 월입니다");
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("올바르지 않은 월 형식입니다");
+        }
+    }
+}

--- a/src/main/java/org/example/studylog/dto/MainPageResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/MainPageResponseDTO.java
@@ -1,0 +1,53 @@
+package org.example.studylog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.studylog.dto.friend.FriendResponseDTO;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MainPageResponseDTO {
+
+    private List<FriendResponseDTO> following;
+    private ProfileDTO profile;
+    private StreakDTO streak;
+    private List<CategoryCountDTO> categories;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileDTO {
+        private String coverImage;
+        private String profileImage;
+        private String name;
+        private String intro;
+        private Integer level;
+        private String uuid;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StreakDTO {
+        private Integer maxStreak;
+        private Map<String, Integer> currentStreak; // "2024-04-01": 2 형태
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CategoryCountDTO {
+        private String name;
+        private Integer count;
+    }
+}

--- a/src/main/java/org/example/studylog/repository/StudyRecordRepository.java
+++ b/src/main/java/org/example/studylog/repository/StudyRecordRepository.java
@@ -92,7 +92,7 @@ public interface StudyRecordRepository extends JpaRepository<StudyRecord, Long> 
     @Query("SELECT sr FROM StudyRecord sr WHERE sr.user = :user AND DATE(sr.createDate) = :date")
     List<StudyRecord> findByUserAndCreateDateDate(@Param("user") User user, @Param("date") LocalDate date);
 
-    // 메인페이지 기능에의해 새로 추가: 카테고리별 기록 개수 조회 (N+1 쿼리 해결용)
+    // ✅ 새로 추가: 카테고리별 기록 개수 조회 (N+1 쿼리 해결용)
     @Query("SELECT sr.category.id, COUNT(sr) FROM StudyRecord sr " +
             "WHERE sr.user = :user " +
             "GROUP BY sr.category.id")

--- a/src/main/java/org/example/studylog/repository/StudyRecordRepository.java
+++ b/src/main/java/org/example/studylog/repository/StudyRecordRepository.java
@@ -91,4 +91,10 @@ public interface StudyRecordRepository extends JpaRepository<StudyRecord, Long> 
     // 특정 날짜에 사용자가 작성한 기록들 조회
     @Query("SELECT sr FROM StudyRecord sr WHERE sr.user = :user AND DATE(sr.createDate) = :date")
     List<StudyRecord> findByUserAndCreateDateDate(@Param("user") User user, @Param("date") LocalDate date);
+
+    // 메인페이지 기능에의해 새로 추가: 카테고리별 기록 개수 조회 (N+1 쿼리 해결용)
+    @Query("SELECT sr.category.id, COUNT(sr) FROM StudyRecord sr " +
+            "WHERE sr.user = :user " +
+            "GROUP BY sr.category.id")
+    List<Object[]> findCategoryCountsByUser(@Param("user") User user);
 }

--- a/src/main/java/org/example/studylog/service/StreakService.java
+++ b/src/main/java/org/example/studylog/service/StreakService.java
@@ -1,0 +1,53 @@
+package org.example.studylog.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.repository.StudyRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StreakService {
+
+    private final StudyRecordRepository studyRecordRepository;
+
+    @Transactional(readOnly = true)
+    public Map<String, Integer> getMonthlyStreakData(User user, String year, String month) {
+        log.info("월별 스트릭 데이터 조회 시작: 사용자={}, {}년 {}월", user.getOauthId(), year, month);
+
+        Map<String, Integer> streakData = new HashMap<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        // YearMonth 객체 생성
+        int yearInt = Integer.parseInt(year);
+        int monthInt = Integer.parseInt(month);
+        YearMonth yearMonth = YearMonth.of(yearInt, monthInt);
+
+        // 해당 월의 모든 날짜에 대해 기록 개수 조회
+        int daysInMonth = yearMonth.lengthOfMonth();
+
+        for (int day = 1; day <= daysInMonth; day++) {
+            LocalDate date = LocalDate.of(yearInt, monthInt, day);
+            Long recordCount = studyRecordRepository.countByUserAndCreateDateDate(user, date);
+
+            // 기록이 있는 날만 Map에 추가
+            if (recordCount > 0) {
+                streakData.put(date.format(formatter), recordCount.intValue());
+            }
+        }
+
+        log.info("월별 스트릭 데이터 조회 완료: 사용자={}, {}년 {}월, 기록 있는 날수={}",
+                user.getOauthId(), year, month, streakData.size());
+
+        return streakData;
+    }
+}


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
-
***
### 💡작업 내용
#### 새로 추가된 파일
- `MainController.java` - /main 엔드포인트 처리
- `MainService.java` - 메인 페이지 데이터 조회 서비스
- `MainPageResponseDTO.java` - 메인 페이지 응답 DTO
- `StreakController.java` - /streak 엔드포인트 처리
- `StreakService.java` - 월별 스트릭 데이터 조회 서비스

#### 수정된 파일
- `LoginController.java` - 기존 /main 엔드포인트 제거 (MainController로 이동)
- `StudyRecordRepository.java` - N+1 쿼리 최적화를 위한 findCategoryCountsByUser() 메서드 추가

#### 구현된 기능
1. 스트릭(메인) 페이지 API (GET /main)
  -   친구 목록 조회 (following)
  -   프로필 정보 반환 (name, profileImage, intro, level, uuid, coverImage)
  -   실제 최대 스트릭 계산 (Streak 엔티티 연동)
  -   최근 30일간 일별 기록 개수 (GitHub 스타일 달력용)
  -   실제 카테고리별 기록 수 계산 (Category-StudyRecord 연동)

2. 월별 스트릭 조회 API (GET /streak?year={year}&month={month})
  -   특정 년월의 모든 날짜별 기록 개수 조회
  -   년월 파라미터 유효성 검증 (2020-2030년, 1-12월)
  -   기록이 있는 날짜만 응답에 포함

#### 성능 최적화 > N+1 쿼리 문제
- 문제 상황:
    - 메인 페이지에서 카테고리별 기록 수를 조회할 때 N+1 쿼리가 발생
    - 기존 코드: 카테고리 목록을 조회한 후, 각 카테고리마다 연관된 StudyRecord 개수를 별도로 조회하는 방식
- 해결방안 두가지:
    1. **각 카테고리별로 개별 카운트 쿼리를 실행하는 방법**: StudyRecordRepository에 countByCategoryAndUser 메서드를 추가하여 카테고리마다 별도 쿼리를 실행하는 방식
    2. **GROUP BY를 활용한 집계 쿼리와 Map 조인 방식**: 모든 카테고리의 기록 수를 한 번의 집계 쿼리로 조회한 후, 결과를 Map으로 변환하여 카테고리 정보와 조인하는 방식
- 선택한 방식과 이유:
    - 2번 선택
    - 이유: 
        - 쿼리 수 최적화 측면에서 첫 번째 방법은 카테고리가 10개일 때 11번의 쿼리가 필요하지만, 두 번째 방법은 카테고리 수와 무관하게 항상 2번의 쿼리만 실행
        - 데이터베이스 효율성 면에서 GROUP BY를 통한 집계 연산을 데이터베이스 레벨에서 처리하므로 네트워크 왕복 횟수가 최소화
                                   **>> 확장성 관점에서 카테고리 수가 증가해도 쿼리 수가 일정 & 메모리 사용량을 예측 가능**
- 구현 위치:
    - `StudyRecordRepository.java`에 집계 쿼리 메서드 추가
    - `MainService.java`의 `getCategoryCountData()` 메서드에서 해당 쿼리 결과를 Map으로 변환하여 활용하도록 구현

#### 성능 최적화 > 잠재적 문제 상황
1. 메모리 사용량
  - 모든 카테고리-카운트 데이터를 메모리에 Map으로 저장
  - 카테고리 수가 매우 많은 경우 (1000개+) 메모리 사용량 증가 가능성

2. 데이터 일관성
  - 카테고리 조회와 기록 수 조회가 별도 쿼리
  - 동시성 환경에서 두 쿼리 사이에 데이터 변경 시 불일치 가능성 (매우 낮음)

3. 코드 복잡성
  - Object[] 배열 처리 및 Map 변환 로직 필요
  - 타입 안정성이 JPA 메서드 쿼리보다 낮음

                                   **>> 결론: 현재 서비스 규모에서는 장점이 단점을 크게 상회하므로 방법 2가 최적의 선택**

***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

1. API 명세서 검토 필요
메인 페이지와 스트릭 조회 API의 차이점이 불분명합니다:

기간 범위 차이:
- 메인 페이지: 최근 30일 vs 현재 월?
- 스트릭 조회: 특정 월 전체

>> 두 API가 거의 동일한 데이터를 반환하고 있어 통합 가능성 검토 필요

2. currentStreak 필드명 검토:
- 실제로는 일별 기록 개수이지만 네이밍이 현재 스트릭으로 오해 가능

***
### 📚참고 문서(선택)


