### PR TITLE
[Feature/#26] 사용자 레벨 변경 이벤트 처리

### DIFF
--- a/src/main/java/org/example/studylog/StudyLogApplication.java
+++ b/src/main/java/org/example/studylog/StudyLogApplication.java
@@ -3,7 +3,9 @@ package org.example.studylog;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class StudyLogApplication {

--- a/src/main/java/org/example/studylog/entity/user/LevelThresholds.java
+++ b/src/main/java/org/example/studylog/entity/user/LevelThresholds.java
@@ -1,0 +1,2 @@
+package org.example.studylog.entity.user;public class LevelThresholds {
+}

--- a/src/main/java/org/example/studylog/entity/user/LevelThresholds.java
+++ b/src/main/java/org/example/studylog/entity/user/LevelThresholds.java
@@ -1,2 +1,35 @@
-package org.example.studylog.entity.user;public class LevelThresholds {
+package org.example.studylog.entity.user;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LevelThresholds {
+    private static final Map<Integer, Integer> thresholds =
+            new LinkedHashMap<>() {{
+                put(1, 10);
+                put(2, 30);
+                put(3, 60);
+                put(4, 100);
+                put(5, 150);
+                put(6, 210);
+                put(7, 280);
+                put(8, 360);
+                put(9, 450);
+                put(10, 550);
+            }};
+
+
+    public static int getLevelForRecordCount(long recordCount){
+        int level = 0;
+
+        for (Map.Entry<Integer, Integer> entry : thresholds.entrySet()) {
+            if(recordCount >= entry.getValue()){
+                level = entry.getKey();
+            } else{
+                break;
+            }
+        }
+
+        return level;
+    }
 }

--- a/src/main/java/org/example/studylog/entity/user/User.java
+++ b/src/main/java/org/example/studylog/entity/user/User.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.example.studylog.entity.StudyRecord;
 import org.example.studylog.entity.category.Category;
 import org.example.studylog.entity.quiz.Quiz;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,10 @@ public class User {
     @Column(nullable = false)
     private int level;
 
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Long recordCount;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
@@ -61,4 +66,24 @@ public class User {
 
     @OneToMany(mappedBy = "user")
     private List<Category> categories = new ArrayList<>();
+
+    // 레벨 증가
+    public void levelUp() {
+        this.level++;
+    }
+
+    // 레벨 감소
+    public void levelDown() {
+        this.level--;
+    }
+
+    // 기록 수 증가
+    public void incrementRecordCount(){
+        this.recordCount++;
+    }
+
+    // 기록 수 감소
+    public void decrementRecordCount(){
+        this.recordCount--;
+    }
 }

--- a/src/main/java/org/example/studylog/entity/user/User.java
+++ b/src/main/java/org/example/studylog/entity/user/User.java
@@ -67,16 +67,6 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Category> categories = new ArrayList<>();
 
-    // 레벨 증가
-    public void levelUp() {
-        this.level++;
-    }
-
-    // 레벨 감소
-    public void levelDown() {
-        this.level--;
-    }
-
     // 기록 수 증가
     public void incrementRecordCount(){
         this.recordCount++;

--- a/src/main/java/org/example/studylog/event/LevelEvent.java
+++ b/src/main/java/org/example/studylog/event/LevelEvent.java
@@ -1,2 +1,18 @@
-package org.example.studylog.event;public class LevelUpEvent {
+package org.example.studylog.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.studylog.entity.user.User;
+
+@Getter
+@AllArgsConstructor
+public class LevelEvent {
+
+    private final User user;
+    private final int newLevel;
+    private final ActionType action;
+
+    public enum ActionType{
+        UP, DOWN
+    }
 }

--- a/src/main/java/org/example/studylog/event/LevelEvent.java
+++ b/src/main/java/org/example/studylog/event/LevelEvent.java
@@ -1,0 +1,2 @@
+package org.example.studylog.event;public class LevelUpEvent {
+}

--- a/src/main/java/org/example/studylog/event/RecordEvent.java
+++ b/src/main/java/org/example/studylog/event/RecordEvent.java
@@ -1,15 +1,13 @@
 package org.example.studylog.event;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.example.studylog.entity.user.User;
 
-public class RecordCreatedEvent {
+@Getter
+@AllArgsConstructor
+public class RecordEvent {
+
     private final User user;
 
-    public RecordCreatedEvent(User user) {
-        this.user = user;
-    }
-
-    public User getUser() {
-        return user;
-    }
 }

--- a/src/main/java/org/example/studylog/event/RecordEvent.java
+++ b/src/main/java/org/example/studylog/event/RecordEvent.java
@@ -1,0 +1,15 @@
+package org.example.studylog.event;
+
+import org.example.studylog.entity.user.User;
+
+public class RecordCreatedEvent {
+    private final User user;
+
+    public RecordCreatedEvent(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/org/example/studylog/event/listener/LevelChangeListener.java
+++ b/src/main/java/org/example/studylog/event/listener/LevelChangeListener.java
@@ -1,6 +1,10 @@
 package org.example.studylog.event.listener;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studylog.entity.user.LevelThresholds;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.event.LevelEvent;
 import org.example.studylog.event.RecordEvent;
 import org.example.studylog.repository.UserRepository;
 import org.springframework.context.ApplicationEventPublisher;
@@ -9,8 +13,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
-public class LevelUpListener {
+public class LevelChangeListener {
 
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -18,14 +23,23 @@ public class LevelUpListener {
     @EventListener
     @Transactional
     public void handleRecordEvent(RecordEvent event) {
-        
+        User currentUser = event.getUser();
+        long recordCount = currentUser.getRecordCount();
 
-        if(event.getAction() == RecordEvent.ActionType.CREATED){
-            // 레벨 체크 (기록 생성 시)
+        log.info("레벨 체크 시작: USER = {}, CURRENT_LEVEL = {}, RECORD_COUNT= {}",
+                currentUser.getOauthId(), currentUser.getLevel(), recordCount);
 
-        }
-        else if(event.getAction() == RecordEvent.ActionType.DELETED){
-            // 레벨 체크 (기록 삭제 시)
+        int lastLevel = currentUser.getLevel();
+        int newLevel = LevelThresholds.getLevelForRecordCount(recordCount);
+        if(lastLevel != newLevel){
+            currentUser.setLevel(newLevel); // 레벨 업데이트
+
+            if(lastLevel > newLevel){
+                eventPublisher.publishEvent(new LevelEvent(currentUser, newLevel, LevelEvent.ActionType.DOWN));
+            }
+            else if(lastLevel < newLevel){
+                eventPublisher.publishEvent(new LevelEvent(currentUser, newLevel, LevelEvent.ActionType.UP));
+            }
         }
     }
 }

--- a/src/main/java/org/example/studylog/event/listener/LevelChangeListener.java
+++ b/src/main/java/org/example/studylog/event/listener/LevelChangeListener.java
@@ -1,0 +1,31 @@
+package org.example.studylog.event.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studylog.event.RecordEvent;
+import org.example.studylog.repository.UserRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class LevelUpListener {
+
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @EventListener
+    @Transactional
+    public void handleRecordEvent(RecordEvent event) {
+        
+
+        if(event.getAction() == RecordEvent.ActionType.CREATED){
+            // 레벨 체크 (기록 생성 시)
+
+        }
+        else if(event.getAction() == RecordEvent.ActionType.DELETED){
+            // 레벨 체크 (기록 삭제 시)
+        }
+    }
+}

--- a/src/main/java/org/example/studylog/event/listener/NotificationListener.java
+++ b/src/main/java/org/example/studylog/event/listener/NotificationListener.java
@@ -1,2 +1,45 @@
-package org.example.studylog.event.listener;public class NotificationListener {
+package org.example.studylog.event.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studylog.dto.notification.NotificationDTO;
+import org.example.studylog.entity.notification.NotificationType;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.event.LevelEvent;
+import org.example.studylog.service.NotificationService;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    @Transactional
+    public void handleLevelChange(LevelEvent event){
+        User currentUser = event.getUser();
+        log.info("레벨 변경 알림 전송: USER={}, LEVEL={}", currentUser.getOauthId(), event.getNewLevel());
+
+        String message = "";
+        if(event.getAction() == LevelEvent.ActionType.UP){
+            message = String.format("Lv.%d 뱃지를 달성했습니다.", event.getNewLevel());
+        }
+        else if(event.getAction() == LevelEvent.ActionType.DOWN){
+            message = String.format("Lv.%d 뱃지로 하락했습니다.", event.getNewLevel());
+        }
+
+        // 알림 보내기
+        notificationService.sendToClient(
+                currentUser.getOauthId(),
+                NotificationDTO.builder()
+                        .content(message)
+                        .type(NotificationType.BADGE)
+                        .build());
+    }
 }

--- a/src/main/java/org/example/studylog/event/listener/NotificationListener.java
+++ b/src/main/java/org/example/studylog/event/listener/NotificationListener.java
@@ -8,10 +8,9 @@ import org.example.studylog.entity.user.User;
 import org.example.studylog.event.LevelEvent;
 import org.example.studylog.service.NotificationService;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -20,6 +19,7 @@ public class NotificationListener {
 
     private final NotificationService notificationService;
 
+    @Async
     @EventListener
     @Transactional
     public void handleLevelChange(LevelEvent event){

--- a/src/main/java/org/example/studylog/event/listener/NotificationListener.java
+++ b/src/main/java/org/example/studylog/event/listener/NotificationListener.java
@@ -1,0 +1,2 @@
+package org.example.studylog.event.listener;public class NotificationListener {
+}

--- a/src/main/java/org/example/studylog/service/StudyRecordService.java
+++ b/src/main/java/org/example/studylog/service/StudyRecordService.java
@@ -113,6 +113,7 @@ public class StudyRecordService {
         log.info("기록 생성 이벤트 발행: USER={}, ID={}", user.getOauthId(), savedStudyRecord.getId());
         user.incrementRecordCount();
         eventPublisher.publishEvent(new RecordEvent(user));
+        log.info("기록 생성 이벤트 종료: USER={}, ID={}", user.getOauthId(), savedStudyRecord.getId());
 
         // 4. 응답 DTO 생성
         StudyRecordDTO recordDTO = convertToStudyRecordDTO(savedStudyRecord);

--- a/src/main/java/org/example/studylog/service/StudyRecordService.java
+++ b/src/main/java/org/example/studylog/service/StudyRecordService.java
@@ -10,9 +10,11 @@ import org.example.studylog.entity.category.Category;
 import org.example.studylog.entity.StudyRecord;
 import org.example.studylog.entity.Streak;
 import org.example.studylog.entity.user.User;
+import org.example.studylog.event.RecordEvent;
 import org.example.studylog.repository.CategoryRepository;
 import org.example.studylog.repository.StudyRecordRepository;
 import org.example.studylog.repository.StreakRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,7 @@ public class StudyRecordService {
     private final StudyRecordRepository studyRecordRepository;
     private final CategoryRepository categoryRepository;
     private final StreakRepository streakRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public StudyRecordDTO updateStudyRecord(User user, Long recordId, UpdateStudyRecordRequestDTO requestDTO) {
@@ -74,6 +77,12 @@ public class StudyRecordService {
 
         // 2. 기록 삭제 (연관된 퀴즈들도 CASCADE로 함께 삭제됨)
         studyRecordRepository.delete(studyRecord);
+
+        // recordCount 감소
+        user.decrementRecordCount();
+        log.info("기록 삭제 이벤트 발행: USER={}, ID={}", user.getOauthId(), recordId);
+        eventPublisher.publishEvent(new RecordEvent(user));
+
         log.info("기록 삭제 완료: ID={}", recordId);
     }
 
@@ -99,6 +108,11 @@ public class StudyRecordService {
 
         // 3. 스트릭 업데이트
         StreakDTO streakDTO = updateUserStreak(user);
+
+        // recordCount 증가 & 이벤트 발행
+        log.info("기록 생성 이벤트 발행: USER={}, ID={}", user.getOauthId(), savedStudyRecord.getId());
+        user.incrementRecordCount();
+        eventPublisher.publishEvent(new RecordEvent(user));
 
         // 4. 응답 DTO 생성
         StudyRecordDTO recordDTO = convertToStudyRecordDTO(savedStudyRecord);


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #26 
***
### 💡작업 내용
- 사용자가 기록을 생성하고 삭제 할 때 `recordCount`가 업데이트 됩니다.
- `recordCount`에 따라 사용자의 레벨이 결정됩니다. 레벨이 변경된다면 사용자에게 알림이 갑니다.
- 레벨이 변경되면 서버에서 이벤트가 발행되고, `@EventListener`를 통해 레벨 업데이트와 알림 발송 로직을 처리합니다.
- 알림 전송은 `@Async`로 비동기 실행되어 기록 생성/삭제 요청의 성능에 영향을 주지 않습니다.
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
***
### 📚참고 문서(선택)


