### PR TITLE
[Refactor/#30] 메인 페이지, 스트릭 수정사항 

### DIFF
--- a/src/main/java/org/example/studylog/controller/MainController.java
+++ b/src/main/java/org/example/studylog/controller/MainController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,7 +23,16 @@ public class MainController {
     private final UserRepository userRepository;
 
     @GetMapping("/main")
-    public ResponseEntity<?> getMainPage(@AuthenticationPrincipal CustomOAuth2User currentUser) {
+    public ResponseEntity<?> getMainPage(
+            @AuthenticationPrincipal CustomOAuth2User currentUser,
+            @RequestParam(required = false) String code) {
+
+        // code 파라미터가 있으면 코드로 조회, 없으면 기존 로직
+        if (code != null && !code.trim().isEmpty()) {
+            return getMainPageByCode(code);  // private 메서드 호출
+        }
+
+        // 기존 로직 (인증된 사용자)
         try {
             log.info("메인 페이지 조회 요청: 사용자={}", currentUser.getName());
 
@@ -31,7 +41,6 @@ public class MainController {
                 return ResponseUtil.buildResponse(401, "접근 권한이 없습니다.", false);
             }
 
-            // MainService에서 메인 페이지 데이터를 조회
             Object mainPageData = mainService.getMainPageData(user);
 
             log.info("메인 페이지 조회 성공: 사용자={}", currentUser.getName());
@@ -44,17 +53,14 @@ public class MainController {
         }
     }
 
-    @GetMapping("/main/{code}")
-    public ResponseEntity<?> getMainPageByCode(@PathVariable String code) {
-        // code로 사용자 조회하여 메인페이지 데이터 반환
+    // 동일 엔드포인트에서 쿼리 지원을 위해 private 메서드로 변경
+    private ResponseEntity<?> getMainPageByCode(String code) {
         try {
             log.info("코드로 메인 페이지 조회 요청: code={}", code);
 
-            // code로 사용자 조회
             User user = userRepository.findByCode(code)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 코드입니다."));
 
-            // MainService에서 메인 페이지 데이터를 조회
             Object mainPageData = mainService.getMainPageData(user);
 
             log.info("코드로 메인 페이지 조회 성공: code={}, 사용자={}", code, user.getOauthId());

--- a/src/main/java/org/example/studylog/controller/MainController.java
+++ b/src/main/java/org/example/studylog/controller/MainController.java
@@ -10,6 +10,7 @@ import org.example.studylog.util.ResponseUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,6 +40,33 @@ public class MainController {
 
         } catch (Exception e) {
             log.error("메인 페이지 조회 중 오류 발생", e);
+            return ResponseUtil.buildResponse(500, "내부 서버 오류입니다. 다시 접속해주세요.", null);
+        }
+    }
+
+    @GetMapping("/main/{code}")
+    public ResponseEntity<?> getMainPageByCode(@PathVariable String code) {
+        // code로 사용자 조회하여 메인페이지 데이터 반환
+        try {
+            log.info("코드로 메인 페이지 조회 요청: code={}", code);
+
+            // code로 사용자 조회
+            User user = userRepository.findByCode(code)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 코드입니다."));
+
+            // MainService에서 메인 페이지 데이터를 조회
+            Object mainPageData = mainService.getMainPageData(user);
+
+            log.info("코드로 메인 페이지 조회 성공: code={}, 사용자={}", code, user.getOauthId());
+
+            return ResponseUtil.buildResponse(200, "메인 페이지 조회에 성공하였습니다.", mainPageData);
+
+        } catch (IllegalArgumentException e) {
+            log.warn("코드로 메인 페이지 조회 실패 - 잘못된 요청: {}", e.getMessage());
+            return ResponseUtil.buildResponse(404, e.getMessage(), null);
+
+        } catch (Exception e) {
+            log.error("코드로 메인 페이지 조회 중 오류 발생", e);
             return ResponseUtil.buildResponse(500, "내부 서버 오류입니다. 다시 접속해주세요.", null);
         }
     }

--- a/src/main/java/org/example/studylog/controller/StreakController.java
+++ b/src/main/java/org/example/studylog/controller/StreakController.java
@@ -27,9 +27,16 @@ public class StreakController {
     @GetMapping("/streak")
     public ResponseEntity<?> getMonthlyStreak(
             @AuthenticationPrincipal CustomOAuth2User currentUser,
+            @RequestParam(required = false) String code,
             @RequestParam("year") String year,
             @RequestParam("month") String month) {
 
+        // code 파라미터가 있으면 코드로 조회
+        if (code != null && !code.trim().isEmpty()) {
+            return getMonthlyStreakByCode(code, year, month);  // private 메서드 호출
+        }
+
+        // 기존 로직 (인증된 사용자)
         try {
             log.info("월별 스트릭 조회 요청: 사용자={}, year={}, month={}",
                     currentUser.getName(), year, month);
@@ -39,10 +46,7 @@ public class StreakController {
                 return ResponseUtil.buildResponse(401, "접근 권한이 없습니다.", false);
             }
 
-            // 년월 유효성 검증
             validateYearMonth(year, month);
-
-            // 월별 스트릭 데이터 조회
             Object monthlyStreakData = streakService.getMonthlyStreakData(user, year, month);
 
             log.info("월별 스트릭 조회 성공: 사용자={}, year={}, month={}",
@@ -52,8 +56,7 @@ public class StreakController {
 
         } catch (IllegalArgumentException e) {
             log.warn("월별 스트릭 조회 실패 - 잘못된 요청: {}", e.getMessage());
-            return ResponseUtil.buildResponse(400, "잘못된 접근입니다",
-                    Map.of("example", e.getMessage()));
+            return ResponseUtil.buildResponse(400, "잘못된 접근입니다", Map.of("example", e.getMessage()));
 
         } catch (Exception e) {
             log.error("월별 스트릭 조회 중 오류 발생", e);
@@ -61,24 +64,15 @@ public class StreakController {
         }
     }
 
-    @GetMapping("/streak/{code}")
-    public ResponseEntity<?> getMonthlyStreakByCode(
-            @PathVariable String code,
-            @RequestParam("year") String year,
-            @RequestParam("month") String month) {
-
+    // private 메서드 추가
+    private ResponseEntity<?> getMonthlyStreakByCode(String code, String year, String month) {
         try {
-            log.info("코드로 월별 스트릭 조회 요청: code={}, year={}, month={}",
-                    code, year, month);
+            log.info("코드로 월별 스트릭 조회 요청: code={}, year={}, month={}", code, year, month);
 
-            // code로 사용자 조회
             User user = userRepository.findByCode(code)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 코드입니다."));
 
-            // 년월 유효성 검증
             validateYearMonth(year, month);
-
-            // 월별 스트릭 데이터 조회
             Object monthlyStreakData = streakService.getMonthlyStreakData(user, year, month);
 
             log.info("코드로 월별 스트릭 조회 성공: code={}, 사용자={}, year={}, month={}",
@@ -88,8 +82,7 @@ public class StreakController {
 
         } catch (IllegalArgumentException e) {
             log.warn("코드로 월별 스트릭 조회 실패 - 잘못된 요청: {}", e.getMessage());
-            return ResponseUtil.buildResponse(400, "잘못된 접근입니다",
-                    Map.of("example", e.getMessage()));
+            return ResponseUtil.buildResponse(400, "잘못된 접근입니다", Map.of("example", e.getMessage()));
 
         } catch (Exception e) {
             log.error("코드로 월별 스트릭 조회 중 오류 발생", e);

--- a/src/main/java/org/example/studylog/dto/MainPageResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/MainPageResponseDTO.java
@@ -30,7 +30,7 @@ public class MainPageResponseDTO {
         private String name;
         private String intro;
         private Integer level;
-        private String uuid;
+        private String code;
     }
 
     @Getter

--- a/src/main/java/org/example/studylog/service/MainService.java
+++ b/src/main/java/org/example/studylog/service/MainService.java
@@ -46,7 +46,7 @@ public class MainService {
                 .name(user.getNickname())
                 .intro(user.getIntro())
                 .level(user.getLevel())
-                .uuid(user.getUuid().toString())
+                .code(user.getCode())
                 .build();
 
         // 3. 스트릭 정보 생성 (현재 월 데이터 활용)

--- a/src/main/java/org/example/studylog/service/MainService.java
+++ b/src/main/java/org/example/studylog/service/MainService.java
@@ -10,6 +10,7 @@ import org.example.studylog.entity.user.User;
 import org.example.studylog.repository.CategoryRepository;
 import org.example.studylog.repository.StreakRepository;
 import org.example.studylog.repository.StudyRecordRepository;
+import org.example.studylog.repository.UserRepository;
 import org.example.studylog.repository.custom.FriendRepositoryImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,7 @@ public class MainService {
     private final StudyRecordRepository studyRecordRepository;
     private final StreakRepository streakRepository;
     private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public MainPageResponseDTO getMainPageData(User user) {
@@ -119,5 +121,24 @@ public class MainService {
                         .count(categoryCountMap.getOrDefault(category.getId(), 0))
                         .build())
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public MainPageResponseDTO getMainPageDataByCode(String code) {
+        log.info("코드로 메인 페이지 데이터 조회 시작: code={}", code);
+
+        // code로 사용자 조회
+        User user = userRepository.findByCode(code)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 코드입니다."));
+
+        log.info("코드로 사용자 조회 완료: code={}, 사용자={}", code, user.getOauthId());
+
+        // 기존 getMainPageData 메서드 로직 재사용
+        MainPageResponseDTO response = getMainPageData(user);
+
+        log.info("코드로 메인 페이지 데이터 조회 완료: code={}, 친구수={}, 카테고리수={}",
+                code, response.getFollowing().size(), response.getCategories().size());
+
+        return response;
     }
 }

--- a/src/main/java/org/example/studylog/service/StreakService.java
+++ b/src/main/java/org/example/studylog/service/StreakService.java
@@ -40,9 +40,11 @@ public class StreakService {
             Long recordCount = studyRecordRepository.countByUserAndCreateDateDate(user, date);
 
             // 기록이 있는 날만 Map에 추가
-            if (recordCount > 0) {
-                streakData.put(date.format(formatter), recordCount.intValue());
-            }
+//            if (recordCount > 0) {
+//                streakData.put(date.format(formatter), recordCount.intValue());
+//            }
+            // 수정: 모든 날 반환
+            streakData.put(date.format(formatter), recordCount.intValue());
         }
 
         log.info("월별 스트릭 데이터 조회 완료: 사용자={}, {}년 {}월, 기록 있는 날수={}",

--- a/src/main/java/org/example/studylog/service/StreakService.java
+++ b/src/main/java/org/example/studylog/service/StreakService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.studylog.entity.user.User;
 import org.example.studylog.repository.StudyRecordRepository;
+import org.example.studylog.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ import java.util.Map;
 public class StreakService {
 
     private final StudyRecordRepository studyRecordRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public Map<String, Integer> getMonthlyStreakData(User user, String year, String month) {
@@ -49,6 +51,24 @@ public class StreakService {
 
         log.info("월별 스트릭 데이터 조회 완료: 사용자={}, {}년 {}월, 기록 있는 날수={}",
                 user.getOauthId(), year, month, streakData.size());
+
+        return streakData;
+    }
+    @Transactional(readOnly = true)
+    public Map<String, Integer> getMonthlyStreakDataByCode(String code, String year, String month) {
+        log.info("코드로 월별 스트릭 데이터 조회 시작: code={}, {}년 {}월", code, year, month);
+
+        // code로 사용자 조회
+        User user = userRepository.findByCode(code)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 코드입니다."));
+
+        log.info("코드로 사용자 조회 완료: code={}, 사용자={}", code, user.getOauthId());
+
+        // 기존 getMonthlyStreakData 메서드 로직 재사용
+        Map<String, Integer> streakData = getMonthlyStreakData(user, year, month);
+
+        log.info("코드로 월별 스트릭 데이터 조회 완료: code={}, 사용자={}, {}년 {}월, 기록 있는 날수={}",
+                code, user.getOauthId(), year, month, streakData.size());
 
         return streakData;
     }

--- a/src/test/java/org/example/studylog/service/StudyRecordServiceTest.java
+++ b/src/test/java/org/example/studylog/service/StudyRecordServiceTest.java
@@ -1,0 +1,287 @@
+package org.example.studylog.service;
+
+import org.example.studylog.dto.studyrecord.*;
+import org.example.studylog.entity.Streak;
+import org.example.studylog.entity.StudyRecord;
+import org.example.studylog.entity.category.Category;
+import org.example.studylog.entity.category.Color;
+import org.example.studylog.entity.user.Role;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.repository.CategoryRepository;
+import org.example.studylog.repository.StreakRepository;
+import org.example.studylog.repository.StudyRecordRepository;
+import org.example.studylog.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class StudyRecordServiceTest {
+
+    @Autowired
+    private StudyRecordService studyRecordService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private StudyRecordRepository studyRecordRepository;
+    @Autowired
+    private StreakRepository streakRepository;
+
+    // === 1. 데이터 무결성 테스트 ===
+
+    @Test
+    @DisplayName("기록 생성 중 카테고리가 삭제되는 경우")
+    void createRecord_CategoryDeletedDuringCreation_ShouldFail() {
+        // Given
+        User user = createTestUser();
+        Category category = createTestCategory(user);
+        CreateStudyRecordRequestDTO requestDTO = createValidRequestDTO(category.getId());
+
+        // 다른 스레드에서 카테고리 삭제 시뮬레이션
+        CompletableFuture.runAsync(() -> {
+            categoryRepository.delete(category);
+            categoryRepository.flush();
+        });
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class,
+                () -> studyRecordService.createStudyRecord(user, requestDTO));
+    }
+
+    @Test
+    @DisplayName("기록 생성 시 제목 길이 경계값 테스트")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 19, 20, 21, 50})
+    void createRecord_TitleLengthBoundary(int titleLength) {
+        // Given
+        User user = createTestUser();
+        Category category = createTestCategory(user);
+
+        CreateStudyRecordRequestDTO requestDTO = new CreateStudyRecordRequestDTO();
+        requestDTO.setCategoryId(category.getId());
+        requestDTO.setTitle("a".repeat(titleLength));
+        requestDTO.setContent("유효한 내용입니다. 최소 10자 이상 작성");
+
+        // When & Then
+        if (titleLength == 0 || titleLength > 20) {
+            assertThrows(Exception.class,
+                    () -> studyRecordService.createStudyRecord(user, requestDTO));
+        } else {
+            assertDoesNotThrow(
+                    () -> studyRecordService.createStudyRecord(user, requestDTO));
+        }
+    }
+
+    @Test
+    @DisplayName("기록 내용에 특수 문자 및 이모지 포함")
+    void createRecord_SpecialCharactersAndEmojis() {
+        // Given
+        User user = createTestUser();
+        Category category = createTestCategory(user);
+
+        String specialContent = "특수문자 테스트 !@#$%^&*()_+ 이모지 테스트 😀🎉📚 " +
+                "HTML 태그 <script>alert('xss')</script> " +
+                "SQL 문자 '; DROP TABLE study_record; --";
+
+        CreateStudyRecordRequestDTO requestDTO = new CreateStudyRecordRequestDTO();
+        requestDTO.setCategoryId(category.getId());
+        requestDTO.setTitle("특수문자 테스트");
+        requestDTO.setContent(specialContent);
+
+        // When
+        CreateStudyRecordResponseDTO result = studyRecordService.createStudyRecord(user, requestDTO);
+
+        // Then
+        assertThat(result.getRecord().getContent()).contains("특수문자 테스트");
+        // XSS 공격 문자열이 그대로 저장되지 않았는지 확인
+        assertThat(result.getRecord().getContent()).doesNotContain("<script>");
+    }
+
+    // === 2. 동시성 테스트 ===
+
+    @Test
+    @DisplayName("동일 사용자가 동시에 여러 기록 생성")
+    void createRecord_ConcurrentCreation_ShouldMaintainDataIntegrity() throws InterruptedException {
+        // Given
+        User user = createTestUser();
+        Category category = createTestCategory(user);
+
+        int threadCount = 10;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        // When - 동시에 10개 기록 생성
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            CompletableFuture.runAsync(() -> {
+                try {
+                    CreateStudyRecordRequestDTO requestDTO = new CreateStudyRecordRequestDTO();
+                    requestDTO.setCategoryId(category.getId());
+                    requestDTO.setTitle("동시 생성 테스트 " + index);
+                    requestDTO.setContent("동시 생성 테스트 내용입니다. " + index);
+
+                    studyRecordService.createStudyRecord(user, requestDTO);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(30, TimeUnit.SECONDS);
+
+        // Then
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(exceptions).isEmpty();
+
+        // 실제 DB에 모든 기록이 저장되었는지 확인
+        List<StudyRecord> records = studyRecordRepository.findByUserOrderByCreateDateDesc(user);
+        assertThat(records).hasSize(threadCount);
+
+        // 스트릭이 정확히 계산되었는지 확인 (같은 날이므로 1이어야 함)
+        Optional<Streak> streak = streakRepository.findByUser(user);
+        assertThat(streak).isPresent();
+        assertThat(streak.get().getCurrentStreak()).isEqualTo(1);
+    }
+
+    // === 3. 필터링 및 검색 테스트 ===
+
+    @Test
+    @DisplayName("페이징 경계값 테스트 - lastId가 Long.MAX_VALUE인 경우")
+    void getRecordsWithFilter_MaxLastId_ShouldReturnEmpty() {
+        // Given
+        User user = createTestUser();
+        createMultipleTestRecords(user, 20);
+
+        StudyRecordFilterRequestDTO requestDTO = new StudyRecordFilterRequestDTO();
+        requestDTO.setLastId(Long.MAX_VALUE);
+        requestDTO.setSize(10);
+
+        // When
+        StudyRecordFilterResponseDTO result = studyRecordService.getStudyRecordsWithFilter(user, requestDTO);
+
+        // Then
+        assertThat(result.getRecords()).isEmpty();
+        assertThat(result.getHasMore()).isFalse();
+        assertThat(result.getNextLastId()).isNull();
+    }
+
+    @Test
+    @DisplayName("잘못된 날짜 형식으로 필터링")
+    @ParameterizedTest
+    @ValueSource(strings = {"2024-13-01", "2024-02-30", "invalid-date", "2024/01/01", ""})
+    void getRecordsWithFilter_InvalidDateFormats_ShouldThrowException(String invalidDate) {
+        // Given
+        User user = createTestUser();
+        StudyRecordFilterRequestDTO requestDTO = new StudyRecordFilterRequestDTO();
+        requestDTO.setDate(invalidDate);
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class,
+                () -> studyRecordService.getStudyRecordsWithFilter(user, requestDTO));
+    }
+
+    @Test
+    @DisplayName("검색어에 SQL Injection 시도")
+    void searchRecords_SqlInjectionAttempt_ShouldBeSafe() {
+        // Given
+        User user = createTestUser();
+        createMultipleTestRecords(user, 5);
+
+        String maliciousQuery = "'; DROP TABLE study_record; SELECT * FROM study_record WHERE '1'='1";
+
+        // When
+        StudyRecordListResponseDTO result = studyRecordService.searchStudyRecordsByTitle(user, maliciousQuery);
+
+        // Then
+        assertThat(result.getRecords()).isEmpty(); // 검색 결과는 없어야 함
+
+        // 테이블이 여전히 존재하는지 확인
+        long recordCount = studyRecordRepository.count();
+        assertThat(recordCount).isGreaterThanOrEqualTo(5);
+    }
+
+    // === 4. 업데이트 및 삭제 테스트 ===
+
+    @Test
+    @DisplayName("기록 수정 중 카테고리 변경 - 존재하지 않는 카테고리로")
+    void updateRecord_NonExistentCategory_ShouldFail() {
+        // Given
+        User user = createTestUser();
+        Category originalCategory = createTestCategory(user);
+        StudyRecord record = createTestRecord(user, originalCategory);
+
+        UpdateStudyRecordRequestDTO requestDTO = new UpdateStudyRecordRequestDTO();
+        requestDTO.setCategoryId(999L); // 존재하지 않는 카테고리
+        requestDTO.setTitle("수정된 제목");
+        requestDTO.setContent("수정된 내용입니다. 최소 10자 이상");
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class,
+                () -> studyRecordService.updateStudyRecord(user, record.getId(), requestDTO));
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 기록 수정 시도")
+    void updateRecord_AlreadyDeletedRecord_ShouldFail() {
+        // Given
+        User user = createTestUser();
+        Category category = createTestCategory(user);
+        StudyRecord record = createTestRecord(user, category);
+        Long recordId = record.getId();
+
+        // 기록 삭제
+        studyRecordService.deleteStudyRecord(user, recordId);
+
+        UpdateStudyRecordRequestDTO requestDTO = createValidUpdateRequestDTO(category.getId());
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class,
+                () -> studyRecordService.updateStudyRecord(user, recordId, requestDTO));
+    }
+
+    // 테스트 데이터 생성 헬퍼 메서드들
+    private User createTestUser() {
+        User user = User.builder()
+                .nickname("테스트유저")
+                .profileImage("test.jpg")
+                .intro("테스트 소개")
+                .level(1)
+                .role(Role.ROLE_USER)
+                .isProfileCompleted(true)
+                .uuid(UUID.randomUUID())
+                .code("TEST1")
+                .oauthId("test_oauth_id")
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Category createTestCategory(User user) {
+        Category category = Category.builder()
+                .user(user)
+                .name("테스트 카테고리")
+                .color(Color.BABY_BLUE)
+                .build();
+        return categoryRepository.save(category);
+    }
+}


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #30 
***
### 💡작업 내용
- 메인페이지 사용자 정보 반환 시 uuid → code로 변경
- 스트릭 API에서 기록이 없는 날도 0으로 반환하도록 수정
- 메인페이지 코드로 조회하는 API 추가 (`/main?code={code}`)
- 스트릭 코드로 조회하는 API 추가 (`/streak?code={code}&year={year}&month={month}`)

* 참고: 코드로 조회하는 API 추가 시 동일한 엔드포인트에서 쿼리파라미터로 조회도 할 수 있게 하기 위해 private 메서드로 분리
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
***
### 📚참고 문서(선택)


