### PR TITLE
[Refactor/#29] 인증 방식을 쿠키에서 헤더로 변경

### DIFF
--- a/src/main/java/org/example/studylog/config/SecurityConfig.java
+++ b/src/main/java/org/example/studylog/config/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/login", "/auth/**", "/error",  // /error 추가
+                        .requestMatchers("/", "/login", "/auth/**", "/error", "/signup",// /error 추가
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",

--- a/src/main/java/org/example/studylog/controller/jwt/AuthController.java
+++ b/src/main/java/org/example/studylog/controller/jwt/AuthController.java
@@ -3,9 +3,12 @@ package org.example.studylog.controller.jwt;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.example.studylog.dto.oauth.TokenDTO;
+import org.example.studylog.entity.user.User;
 import org.example.studylog.jwt.JWTUtil;
 import org.example.studylog.service.TokenService;
 import org.example.studylog.util.CookieUtil;
+import org.example.studylog.util.ResponseUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,23 +39,19 @@ public class AuthController {
             }
         }
 
-        // 리프레시 토큰 검증
-        tokenService.validateRefreshToken(refresh);
+        TokenDTO tokenDTO = tokenService.reissueAccessToken(refresh);
 
-        // 새로운 access 토큰 발급
-        String oauthId = jwtUtil.getOauthId(refresh);
-        String role = jwtUtil.getRole(refresh);
+        // Refresh 토큰은 쿠키로 전달
+        response.addCookie(CookieUtil.createCookie("refresh", tokenDTO.getRefreshToken()));
 
-        String newAccess = jwtUtil.createJwt("access", oauthId, role, 600000L);
-        String newRefresh = jwtUtil.createJwt("refresh", oauthId, role, 86400000L);
+        // Access 토큰, code, isNewUser는 body로 전달
+        TokenDTO.ResponseDTO dto = TokenDTO.ResponseDTO.builder()
+                .accessToken(tokenDTO.getAccessToken())
+                .code(tokenDTO.getCode())
+                .isNewUser(tokenDTO.isNewUser())
+                .build();
 
-        // Refresh DB에 기존의 Refresh 토큰 삭제 후 새로운 Refresh 토큰 저장
-        tokenService.replaceRefreshToken(refresh, newRefresh, oauthId, 86400000L);
-
-        response.addCookie(CookieUtil.createCookie("access", newAccess));
-        response.addCookie(CookieUtil.createCookie("refresh", newRefresh));
-
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseUtil.buildResponse(200, "토큰 재발급 완료", dto);
     }
 
 }

--- a/src/main/java/org/example/studylog/dto/oauth/TokenDTO.java
+++ b/src/main/java/org/example/studylog/dto/oauth/TokenDTO.java
@@ -1,0 +1,23 @@
+package org.example.studylog.dto.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDTO {
+
+    private String refreshToken;
+    private String accessToken;
+    private String code;
+    private boolean isNewUser;
+
+    @Getter
+    @Builder
+    public static class ResponseDTO {
+        private String accessToken;
+        private String code;
+        private boolean isNewUser;
+    }
+}

--- a/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
@@ -43,21 +43,16 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String role = auth.getAuthority();
 
         // 토큰 생성
-        String access = jwtUtil.createJwt("access", oauthId, role, 86400000L);
         String refresh = jwtUtil.createJwt("refresh", oauthId, role, 86400000L);
 
         // refresh 토큰 저장
         tokenService.addRefreshEntity(oauthId, refresh, 86400000L);
 
-        response.addCookie(CookieUtil.createCookie("access", access));
         response.addCookie(CookieUtil.createCookie("refresh", refresh));
 
-        // 사용자의 정보 입력 유무에 따라 분기
-        if(!customUserDetails.isProfileCompleted()){
-            response.sendRedirect("http://localhost:8080/signup");
-        } else{
-            response.sendRedirect("http://localhost:8080/main");
-        }
+        // 로그인 완료 화면으로 리다이렉션
+        response.sendRedirect("http://localhost:8080/signup");
+
     }
 
 }

--- a/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
@@ -50,7 +50,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         response.addCookie(CookieUtil.createCookie("refresh", refresh));
 
-        // 로그인 완료 화면으로 리다이렉션
+        // 회원가입 화면으로 리다이렉션(임시: 프론트 로그인 완료 화면으로 변경 예정)
         response.sendRedirect("http://localhost:8080/signup");
 
     }


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #29 
***
### 💡작업 내용
- 기존의 쿠키 방식 인증을 헤더로 변경: 
    - 모든 요청 헤더의 `Authorization`에 Access 토큰을 담아야 함
- 로그인 완료 시 임시로 `/signup`으로 이동
   - 추후 프론트의 로그인 완료 페이지로 리다이렉션 하도록 변경 예정
- 토큰 재발급 요청 시, `AccessToken`과 사용자의 `code`, 기존 유저 여부를 판별하는 `newUser` 값을 body에 담아 응답
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
***
### 📚참고 문서(선택)


