### PR TITLE
fix: main page follow check

### DIFF
--- a/src/main/java/org/example/studylog/controller/MainController.java
+++ b/src/main/java/org/example/studylog/controller/MainController.java
@@ -45,14 +45,28 @@ public class MainController {
                                             + "\"status\": 200,"
                                             + "\"message\": \"메인 페이지 조회에 성공하였습니다.\","
                                             + "\"data\": {"
-                                            + "\"todayRecords\": 3,"
-                                            + "\"currentStreak\": 5,"
-                                            + "\"totalRecords\": 127,"
+                                            + "\"following\": [],"
+                                            + "\"profile\": {"
+                                            + "\"coverImage\": \"https://example.com/bg.jpg\","
+                                            + "\"profileImage\": \"https://example.com/profile.jpg\","
+                                            + "\"name\": \"홍길동\","
+                                            + "\"intro\": \"안녕하세요! 개발 공부 중입니다.\","
+                                            + "\"level\": 5,"
+                                            + "\"code\": \"ABC123\""
+                                            + "},"
+                                            + "\"streak\": {"
+                                            + "\"maxStreak\": 15,"
+                                            + "\"recordCountPerDay\": {"
+                                            + "\"2025-01-10\": 2,"
+                                            + "\"2025-01-11\": 1,"
+                                            + "\"2025-01-12\": 3"
+                                            + "}"
+                                            + "},"
                                             + "\"categories\": ["
-                                            + "{\"id\": 1, \"name\": \"Spring Boot\", \"color\": \"#FF5733\"},"
-                                            + "{\"id\": 2, \"name\": \"React\", \"color\": \"#61DAFB\"}"
+                                            + "{\"name\": \"Spring Boot\", \"count\": 25},"
+                                            + "{\"name\": \"React\", \"count\": 18}"
                                             + "],"
-                                            + "\"recentRecords\": []"
+                                            + "\"isFollowing\": true"
                                             + "}"
                                             + "}"
                             )
@@ -108,7 +122,7 @@ public class MainController {
 
         // code 파라미터가 있으면 코드로 조회, 없으면 기존 로직
         if (code != null && !code.trim().isEmpty()) {
-            return getMainPageByCode(code);  // private 메서드 호출
+            return getMainPageByCode(code, currentUser);  // private 메서드 호출
         }
 
         // 기존 로직 (인증된 사용자)
@@ -133,16 +147,22 @@ public class MainController {
     }
 
     // 동일 엔드포인트에서 쿼리 지원을 위해 private 메서드로 변경
-    private ResponseEntity<?> getMainPageByCode(String code) {
+    private ResponseEntity<?> getMainPageByCode(String code, CustomOAuth2User currentUser) {
         try {
             log.info("코드로 메인 페이지 조회 요청: code={}", code);
 
-            User user = userRepository.findByCode(code)
+            User targetUser = userRepository.findByCode(code)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 코드입니다."));
 
-            Object mainPageData = mainService.getMainPageData(user);
+            // 현재 사용자가 있으면 팔로우 여부 확인
+            User currentUserEntity = null;
+            if (currentUser != null) {
+                currentUserEntity = userRepository.findByOauthId(currentUser.getName());
+            }
 
-            log.info("코드로 메인 페이지 조회 성공: code={}, 사용자={}", code, user.getOauthId());
+            Object mainPageData = mainService.getMainPageDataWithFollowStatus(targetUser, currentUserEntity);
+
+            log.info("코드로 메인 페이지 조회 성공: code={}, 사용자={}", code, targetUser.getOauthId());
 
             return ResponseUtil.buildResponse(200, "메인 페이지 조회에 성공하였습니다.", mainPageData);
 

--- a/src/main/java/org/example/studylog/dto/MainPageResponseDTO.java
+++ b/src/main/java/org/example/studylog/dto/MainPageResponseDTO.java
@@ -19,6 +19,7 @@ public class MainPageResponseDTO {
     private ProfileDTO profile;
     private StreakDTO streak;
     private List<CategoryCountDTO> categories;
+    private Boolean isFollowing;
 
     @Getter
     @Builder


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #40 
***
### 💡작업 내용
  - Swagger 문서 예시 수정: `/main` 엔드포인트의 응답 예시를 실제 API 구조에 맞게 수정
    - 기존의 잘못된 필드(`todayRecords`, `currentStreak`, `totalRecords`) 제거
    - 실제 응답 구조(`following`, `profile`, `streak`, `categories`) 반영
    - `profile` 객체에 `coverImage`(배경 이미지)와 `level`(유저 레벨) 필드 포함

  - 팔로우 여부 확인 기능 추가: 친구 페이지 조회 시 팔로우 상태 표시
    - `MainPageResponseDTO`에 `isFollowing` 필드 추가
    - `MainService`에 `getMainPageDataWithFollowStatus()` 메서드 구현
    - `/main?code={code}` 엔드포인트에서 현재 사용자와 대상 사용자 간 팔로우 관계 확인
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
***
### 📚참고 문서(선택)
- `/main?code={code}`에서 사용자 본인의 코드를 입력할 시 null, 팔로우 중인 사용자는 true, 팔로우하지 않는 사용자는 false

