### PR TITLE
[Feat/#51] Servlet Cookie를 ResponseCookie로 변경

### DIFF
--- a/src/main/java/org/example/studylog/controller/jwt/AuthController.java
+++ b/src/main/java/org/example/studylog/controller/jwt/AuthController.java
@@ -15,6 +15,7 @@ import org.example.studylog.jwt.JWTUtil;
 import org.example.studylog.service.TokenService;
 import org.example.studylog.util.CookieUtil;
 import org.example.studylog.util.ResponseUtil;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -66,7 +67,8 @@ public class AuthController {
         TokenDTO tokenDTO = tokenService.reissueAccessToken(refresh);
 
         // Refresh 토큰은 쿠키로 전달
-        response.addCookie(CookieUtil.createCookie("refresh", tokenDTO.getRefreshToken()));
+        ResponseCookie cookie = CookieUtil.createCookie("refresh", tokenDTO.getRefreshToken());
+        response.addHeader("Set-Cookie", cookie.toString());
 
         // Access 토큰, code, isNewUser는 body로 전달
         TokenDTO.ResponseDTO dto = TokenDTO.ResponseDTO.builder()

--- a/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
@@ -9,6 +9,7 @@ import org.example.studylog.jwt.JWTUtil;
 import org.example.studylog.service.TokenService;
 import org.example.studylog.util.CookieUtil;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -52,7 +53,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // refresh 토큰 저장
         tokenService.addRefreshEntity(oauthId, refresh, 86400000L);
 
-        response.addCookie(CookieUtil.createCookie("refresh", refresh));
+        // ResponseCookie 생성하여 응답 헤더에 추가
+        ResponseCookie cookie = CookieUtil.createCookie("refresh", refresh);
+        response.addHeader("Set-Cookie", cookie.toString());
 
         // 회원가입 화면으로 리다이렉션(임시: 프론트 로그인 완료 화면으로 변경 예정)
         response.sendRedirect(redirectUri);

--- a/src/main/java/org/example/studylog/util/CookieUtil.java
+++ b/src/main/java/org/example/studylog/util/CookieUtil.java
@@ -1,15 +1,16 @@
 package org.example.studylog.util;
 
-import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 
 public class CookieUtil {
-    public static Cookie createCookie(String key, String value){
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60*60*60);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-//        cookie.setSecure(true);
-
-        return cookie;
+    public static ResponseCookie createCookie(String key, String value){
+        return ResponseCookie.from(key, value)
+                .httpOnly(true)              // JS 접근 불가
+                .path("/")                   // 모든 경로에서 쿠키 전송
+                .maxAge(60 * 60 * 60)        // 유효 시간 (초 단위)
+//                .secure(true)                // HTTPS에서만 전송
+//                .domain(".studylog.shop")    // 도메인 지정 (서브도메인 포함)
+//                .sameSite("None")            // 크로스 도메인 쿠키 허용 시 필요
+                .build();
     }
 }


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #51 
***
### 💡작업 내용
- 기존의 쿠키 발급 방식을 Servlet Cookie에서 ResponseCookie로 변경
- Samesite 옵션을 추가함. 배포 시, Secure, domain 옵션과 함께 활성화할 예정
- 변경된 쿠키 발급 로직을 반영함.
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
***
### 📚참고 문서(선택)


