### PR TITLE
[Feat/#39] 회원 탈퇴 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // flyway
+    implementation "org.flywaydb:flyway-core:11.11.1"
+    implementation "org.flywaydb:flyway-database-postgresql:11.11.1"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/studylog/client/GoogleClient.java
+++ b/src/main/java/org/example/studylog/client/GoogleClient.java
@@ -1,2 +1,22 @@
-package org.example.studylog.client;public interface GoogleClient {
+package org.example.studylog.client;
+
+import org.example.studylog.dto.oauth.OAuthTokenResponse;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+@HttpExchange(accept = MediaType.APPLICATION_JSON_VALUE)
+public interface GoogleClient {
+
+    // Refresh 토큰으로 액세스 토큰 재발급
+    @PostExchange(url = "/token", contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    OAuthTokenResponse reissueToken(@RequestBody MultiValueMap<String, String> form);
+
+    // 토큰 리보크(연결 해제)
+    @PostExchange(url = "/revoke", contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    void unlink(@RequestParam String token);
+
 }

--- a/src/main/java/org/example/studylog/client/GoogleClient.java
+++ b/src/main/java/org/example/studylog/client/GoogleClient.java
@@ -1,0 +1,2 @@
+package org.example.studylog.client;public interface GoogleClient {
+}

--- a/src/main/java/org/example/studylog/client/KakaoApiClient.java
+++ b/src/main/java/org/example/studylog/client/KakaoApiClient.java
@@ -1,0 +1,2 @@
+package org.example.studylog.client;public class KakaoApiClient {
+}

--- a/src/main/java/org/example/studylog/client/KakaoApiClient.java
+++ b/src/main/java/org/example/studylog/client/KakaoApiClient.java
@@ -1,2 +1,17 @@
-package org.example.studylog.client;public class KakaoApiClient {
+package org.example.studylog.client;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+@HttpExchange(accept = MediaType.APPLICATION_JSON_VALUE)
+public interface KakaoApiClient {
+
+    @PostExchange(url = "/v1/user/unlink", contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    void unlink(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
+                @RequestBody MultiValueMap<String, String> form);
 }

--- a/src/main/java/org/example/studylog/client/KakaoAuthClient.java
+++ b/src/main/java/org/example/studylog/client/KakaoAuthClient.java
@@ -1,4 +1,18 @@
 package org.example.studylog.client;
 
-public interface KakaoClient {
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import org.example.studylog.dto.oauth.OAuthTokenResponse;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+@HttpExchange(accept = MediaType.APPLICATION_JSON_VALUE)
+public interface KakaoAuthClient {
+
+    // POST /oauth/token  (x-www-form-urlencoded)
+    @PostExchange(url = "/oauth/token",
+            contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    OAuthTokenResponse refreshToken(@RequestBody MultiValueMap<String, String> form);
 }

--- a/src/main/java/org/example/studylog/client/KakaoAuthClient.java
+++ b/src/main/java/org/example/studylog/client/KakaoAuthClient.java
@@ -1,0 +1,4 @@
+package org.example.studylog.client;
+
+public interface KakaoClient {
+}

--- a/src/main/java/org/example/studylog/config/HttpClientConfig.java
+++ b/src/main/java/org/example/studylog/config/HttpClientConfig.java
@@ -1,9 +1,14 @@
 package org.example.studylog.config;
 
 import org.example.studylog.client.ChatGptClient;
+import org.example.studylog.client.GoogleClient;
+import org.example.studylog.client.KakaoApiClient;
+import org.example.studylog.client.KakaoAuthClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
@@ -26,5 +31,42 @@ public class HttpClientConfig {
         HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
 
         return factory.createClient(ChatGptClient.class);
+    }
+
+    @Bean
+    public GoogleClient googleClient(){
+        RestClient restClient = RestClient.builder()
+                .baseUrl("https://oauth2.googleapis.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build();
+
+        return factory.createClient(GoogleClient.class);
+
+    }
+
+    @Bean
+    public KakaoAuthClient kakaoAuthClient(RestClient.Builder builder) {
+        RestClient rc = builder
+                .baseUrl("https://kauth.kakao.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        return HttpServiceProxyFactory.builderFor(RestClientAdapter.create(rc))
+                .build()
+                .createClient(KakaoAuthClient.class);
+    }
+
+    @Bean
+    public KakaoApiClient kakaoApiClient(RestClient.Builder builder) {
+        RestClient rc = builder
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        return HttpServiceProxyFactory.builderFor(RestClientAdapter.create(rc))
+                .build()
+                .createClient(KakaoApiClient.class);
     }
 }

--- a/src/main/java/org/example/studylog/controller/UserController.java
+++ b/src/main/java/org/example/studylog/controller/UserController.java
@@ -121,4 +121,23 @@ public class UserController {
             return ResponseUtil.buildResponse(500, "내부 서버 오류입니다", null);
         }
     }
+
+    @DeleteMapping
+    public ResponseEntity<?> deleteUser(@AuthenticationPrincipal CustomOAuth2User currentUser){
+        try {
+            log.info("유저 삭제 요청: 사용자={}", currentUser.getName());
+            String oauthId = currentUser.getName();
+            userService.deleteAccount(oauthId);
+            log.info("유저 삭제 완료: 사용자={}", currentUser.getName());
+
+            return ResponseUtil.buildResponse(204, "유저 삭제 완료", null);
+        } catch (IllegalStateException e){
+            log.warn("유저 삭제 실패 - 잘못된 요청: {}", e.getMessage());
+            return ResponseUtil.buildResponse(400, e.getMessage(), null);
+        } catch (Exception e){
+            log.error("유저 삭제 중 오류 발생", e);
+            return ResponseUtil.buildResponse(500, "내부 서버 오류입니다", null);
+        }
+
+    }
 }

--- a/src/main/java/org/example/studylog/controller/UserController.java
+++ b/src/main/java/org/example/studylog/controller/UserController.java
@@ -122,6 +122,11 @@ public class UserController {
         }
     }
 
+    @Operation(summary = "회원 탈퇴")
+    @ApiResponse(responseCode = "204", description = "유저 삭제 완료",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ResponseDTO.class)))
     @DeleteMapping
     public ResponseEntity<?> deleteUser(@AuthenticationPrincipal CustomOAuth2User currentUser){
         try {
@@ -138,6 +143,5 @@ public class UserController {
             log.error("유저 삭제 중 오류 발생", e);
             return ResponseUtil.buildResponse(500, "내부 서버 오류입니다", null);
         }
-
     }
 }

--- a/src/main/java/org/example/studylog/dto/oauth/OAuthTokenResponse.java
+++ b/src/main/java/org/example/studylog/dto/oauth/OAuthTokenResponse.java
@@ -1,23 +1,19 @@
 package org.example.studylog.dto.oauth;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
-public class KakaoTokenResponse {
-
-    @JsonProperty("token_type")
-    private String tokenType;           // "bearer"
-    @JsonProperty("access_token")
-    private String accessToken;
-    @JsonProperty("expires_in")
-    private Long expiresIn;
-    @JsonProperty("scope")
-    private String scope;               // 선택
-
-    // refresh 요청 시, 남은 유효기간이 짧을 때만 새 refresh_token을 줄 수 있음
-    @JsonProperty("refresh_token")
-    private String refreshToken;        // 선택
-    @JsonProperty("refresh_token_expires_in")
-    private Long refreshTokenExpiresIn; // 선택
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OAuthTokenResponse {
+    @JsonProperty("access_token") private String accessToken;
+    @JsonProperty("expires_in")   private Long   expiresIn;
+    @JsonProperty("token_type")   private String tokenType; // "Bearer"/"bearer"
+    @JsonProperty("scope")        private String scope;     // 선택
+    @JsonProperty("refresh_token") private String refreshToken; // 선택
+    // 카카오 전용(선택)
+    @JsonProperty("refresh_token_expires_in") private Long refreshTokenExpiresIn;
+    // 구글 OIDC 선택
+    @JsonProperty("id_token") private String idToken;
 }

--- a/src/main/java/org/example/studylog/dto/oauth/OAuthTokenResponse.java
+++ b/src/main/java/org/example/studylog/dto/oauth/OAuthTokenResponse.java
@@ -1,0 +1,23 @@
+package org.example.studylog.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;           // "bearer"
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+    @JsonProperty("scope")
+    private String scope;               // 선택
+
+    // refresh 요청 시, 남은 유효기간이 짧을 때만 새 refresh_token을 줄 수 있음
+    @JsonProperty("refresh_token")
+    private String refreshToken;        // 선택
+    @JsonProperty("refresh_token_expires_in")
+    private Long refreshTokenExpiresIn; // 선택
+}

--- a/src/main/java/org/example/studylog/entity/Friend.java
+++ b/src/main/java/org/example/studylog/entity/Friend.java
@@ -3,6 +3,8 @@ package org.example.studylog.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.studylog.entity.user.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Setter
@@ -18,10 +20,12 @@ public class Friend {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "friend_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User friend;
 
 }

--- a/src/main/java/org/example/studylog/entity/Streak.java
+++ b/src/main/java/org/example/studylog/entity/Streak.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.example.studylog.entity.user.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDate;
 
@@ -22,6 +24,7 @@ public class Streak extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(name = "current_streak", nullable = false)

--- a/src/main/java/org/example/studylog/entity/StudyRecord.java
+++ b/src/main/java/org/example/studylog/entity/StudyRecord.java
@@ -9,6 +9,8 @@ import lombok.experimental.SuperBuilder;
 import org.example.studylog.entity.category.Category;
 import org.example.studylog.entity.quiz.Quiz;
 import org.example.studylog.entity.user.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,10 +39,12 @@ public class StudyRecord extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Category category;
 
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/org/example/studylog/entity/category/Category.java
+++ b/src/main/java/org/example/studylog/entity/category/Category.java
@@ -9,6 +9,8 @@ import lombok.experimental.SuperBuilder;
 import org.example.studylog.entity.StudyRecord;
 import org.example.studylog.entity.quiz.Quiz;
 import org.example.studylog.entity.user.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +35,7 @@ public class Category {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @OneToMany(mappedBy = "category")

--- a/src/main/java/org/example/studylog/entity/notification/Notification.java
+++ b/src/main/java/org/example/studylog/entity/notification/Notification.java
@@ -3,6 +3,8 @@ package org.example.studylog.entity.notification;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.studylog.entity.user.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -22,6 +24,7 @@ public class Notification {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/example/studylog/entity/quiz/Quiz.java
+++ b/src/main/java/org/example/studylog/entity/quiz/Quiz.java
@@ -10,6 +10,8 @@ import org.example.studylog.entity.BaseEntity;
 import org.example.studylog.entity.StudyRecord;
 import org.example.studylog.entity.category.Category;
 import org.example.studylog.entity.user.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -44,14 +46,17 @@ public class Quiz extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "record_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private StudyRecord record;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Category category;
 
 }

--- a/src/main/java/org/example/studylog/entity/user/User.java
+++ b/src/main/java/org/example/studylog/entity/user/User.java
@@ -67,6 +67,9 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Category> categories = new ArrayList<>();
 
+    @Column(length = 1000)
+    private String refreshToken;
+
     // 기록 수 증가
     public void incrementRecordCount(){
         this.recordCount++;

--- a/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/org/example/studylog/oauth2/CustomSuccessHandler.java
@@ -5,11 +5,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.example.studylog.dto.oauth.CustomOAuth2User;
+import org.example.studylog.entity.user.User;
 import org.example.studylog.jwt.JWTUtil;
+import org.example.studylog.repository.UserRepository;
 import org.example.studylog.service.TokenService;
 import org.example.studylog.util.CookieUtil;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -23,10 +28,16 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JWTUtil jwtUtil;
     private final TokenService tokenService;
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final UserRepository userRepository;
 
-    public CustomSuccessHandler(JWTUtil jwtUtil, TokenService tokenService) {
+    public CustomSuccessHandler(JWTUtil jwtUtil, TokenService tokenService,
+                                OAuth2AuthorizedClientService authorizedClientService,
+                                UserRepository userRepository) {
         this.jwtUtil = jwtUtil;
         this.tokenService = tokenService;
+        this.authorizedClientService = authorizedClientService;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -36,6 +47,28 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
 
         String oauthId = customUserDetails.getName();
+
+        // registrationId (예: "google", "kakao")
+        String registrationId = ((org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken) authentication)
+                .getAuthorizedClientRegistrationId();
+
+        // 이제 authorizedClientService에서 클라이언트 정보를 가져올 수 있음
+        OAuth2AuthorizedClient authorizedClient = authorizedClientService.loadAuthorizedClient(
+                registrationId,
+                oauthId
+        );
+
+        // Refresh Token 가져오기
+        OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+
+        if (refreshToken != null) {
+            // DB에서 사용자 조회 후 Refresh Token 업데이트
+            User user = userRepository.findByOauthId(oauthId);
+            if (user != null) {
+                user.setRefreshToken(refreshToken.getTokenValue());
+                userRepository.save(user);
+            }
+        }
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();

--- a/src/main/java/org/example/studylog/repository/RefreshRepository.java
+++ b/src/main/java/org/example/studylog/repository/RefreshRepository.java
@@ -10,4 +10,6 @@ public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
 
     @Transactional
     void deleteByRefresh(String refresh);
+
+    void deleteAllByOauthId(String oauthId);
 }

--- a/src/main/java/org/example/studylog/service/UserService.java
+++ b/src/main/java/org/example/studylog/service/UserService.java
@@ -6,6 +6,7 @@ import org.example.studylog.dto.*;
 import org.example.studylog.entity.user.User;
 import org.example.studylog.exception.UserNotFoundException;
 import org.example.studylog.repository.FriendRepository;
+import org.example.studylog.repository.RefreshRepository;
 import org.example.studylog.repository.UserRepository;
 import org.example.studylog.util.ResponseUtil;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final AwsS3Service awsS3Service;
     private final FriendRepository friendRepository;
+    private final RefreshRepository refreshRepository;
 
     @Transactional
     public ProfileResponseDTO createUserProfile(ProfileCreateRequestDTO request, String oauthId){
@@ -133,5 +135,28 @@ public class UserService {
         log.info("배경화면 수정 완료: 사용자={}, 배경화면 url = {}", oauthId, backImageUrl);
 
         return responseDTO;
+    }
+
+    @Transactional
+    public void deleteAccount(String oauthId) {
+        User user = userRepository.findByOauthId(oauthId);
+        if(user == null)
+            throw new IllegalArgumentException("존재하지 않는 사용자");
+
+        log.info("사용자 삭제 시작: 사용자 = {}", oauthId);
+
+        // 1. S3 버킷의 이미지 삭제 (프로필 + 배경화면 이미지)
+        awsS3Service.deleteFileByKey(user.getProfileImage());
+        awsS3Service.deleteFileByKey(user.getBackImage());
+
+        // 2. Refresh 토큰 삭제
+        refreshRepository.deleteAllByOauthId(oauthId);
+
+        // 3. 외부 연동 해제
+        
+
+        // 4. 유저 삭제
+        userRepository.delete(user);
+
     }
 }

--- a/src/main/java/org/example/studylog/service/UserService.java
+++ b/src/main/java/org/example/studylog/service/UserService.java
@@ -8,6 +8,7 @@ import org.example.studylog.exception.UserNotFoundException;
 import org.example.studylog.repository.FriendRepository;
 import org.example.studylog.repository.RefreshRepository;
 import org.example.studylog.repository.UserRepository;
+import org.example.studylog.service.oauth.ExternalOAuthUnlinkService;
 import org.example.studylog.util.ResponseUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ public class UserService {
     private final AwsS3Service awsS3Service;
     private final FriendRepository friendRepository;
     private final RefreshRepository refreshRepository;
+    private final ExternalOAuthUnlinkService externalOAuthUnlinkService;
 
     @Transactional
     public ProfileResponseDTO createUserProfile(ProfileCreateRequestDTO request, String oauthId){
@@ -153,7 +155,11 @@ public class UserService {
         refreshRepository.deleteAllByOauthId(oauthId);
 
         // 3. 외부 연동 해제
-        
+        try {
+            externalOAuthUnlinkService.unlink(user);
+        } catch (Exception e) {
+            log.error("외부 연동 해제 중 오류(계정 삭제는 계속): {}", e.getMessage(), e);
+        }
 
         // 4. 유저 삭제
         userRepository.delete(user);

--- a/src/main/java/org/example/studylog/service/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/org/example/studylog/service/oauth/CustomOAuth2UserService.java
@@ -22,13 +22,9 @@ import java.util.UUID;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
-    private final OAuth2AuthorizedClientService authorizedClientService;
 
-    public CustomOAuth2UserService(
-            UserRepository userRepository,
-            OAuth2AuthorizedClientService authorizedClientService) {
+    public CustomOAuth2UserService(UserRepository userRepository) {
         this.userRepository = userRepository;
-        this.authorizedClientService = authorizedClientService;
     }
 
     @Override
@@ -39,20 +35,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         System.out.println(registrationId);
-
-        // OAuth2AuthorizedClientService 를 통해 인증된 클라이언트 정보 로드
-        OAuth2AuthorizedClient authorizedClient = authorizedClientService.loadAuthorizedClient(
-                registrationId, oAuth2User.getName()
-        );
-
-        // RefreshToken 가져오기
-        OAuth2RefreshToken refreshToken = null;
-        if (authorizedClient != null){
-            refreshToken = authorizedClient.getRefreshToken();
-            if (refreshToken != null) {
-                log.info("Refresh Token for {}: {}", registrationId, refreshToken.getTokenValue());
-            }
-        }
 
         OAuth2Response oAuth2Response = null;
         if (registrationId.equals("kakao")){
@@ -83,7 +65,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .uuid(UUID.randomUUID())
                     .code(generateCode())
                     .oauthId(oauthId)
-                    .refreshToken(refreshToken.getTokenValue())
                     .build();
 
             userRepository.save(user);

--- a/src/main/java/org/example/studylog/service/oauth/ExternalOAuthUnlinkService.java
+++ b/src/main/java/org/example/studylog/service/oauth/ExternalOAuthUnlinkService.java
@@ -1,2 +1,80 @@
-package org.example.studylog.service.oauth;public class ExternalOAuthUnlinkService {
+package org.example.studylog.service.oauth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studylog.dto.oauth.OAuthTokenResponse;
+import org.example.studylog.entity.user.User;
+import org.example.studylog.util.AesGcmEncryptor;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExternalOAuthUnlinkService {
+
+    private final GoogleOAuthService googleOAuthService;
+    private final KakaoOAuthService kakaoOAuthService;
+    private final AesGcmEncryptor encryptor;
+
+    public void unlink(User user){
+        if (user == null || user.getOauthId() == null) return;
+
+        String oauthId = user.getOauthId();
+        String[] parts = oauthId.split("_", 2);
+        if(parts.length < 2){
+            log.warn("올바른 oauthId 형식이 아님: {}", oauthId);
+            return;
+        }
+        String provider = parts[0];
+        String providerUserId = parts[1];
+
+        try {
+            if(provider.equals("google")){
+                unlinkGoogle(user);
+            }
+            else if(provider.equals("kakao")){
+                unlinkKakao(user, providerUserId);
+            }
+            else {
+                log.info("지원하지 않는 provider: {}", provider);
+            }
+        } catch (Exception e){
+            log.error("외부 연동 해제 실패: provider={}, oauthId={}, msg={}",
+                    provider, oauthId, e.getMessage());
+        }
+    }
+
+    private void unlinkGoogle(User user){
+        String enc = user.getRefreshToken();
+        String refresh = encryptor.decrypt(enc);  // 복호화
+
+        // RefreshToken으로 revoke 요청 보내기
+        if (refresh != null && !refresh.isBlank()){
+            googleOAuthService.revoke(refresh);
+            log.info("Google revoke by refresh_token 완료");
+        } else {
+            log.info("Google refresh_token 없음 -> revoke 생략");
+        }
+    }
+
+    private void unlinkKakao(User user, String kakaoUserId){
+        // 1순위: Admin Key 방식(사용자 토큰 불필요)
+        if(kakaoOAuthService.hasAdminKey()){
+            kakaoOAuthService.unlinkWithAdminKey(Long.parseLong(kakaoUserId));
+            log.info("Kakao unlink by AdminKey 완료: user_id={}", kakaoUserId);
+            return;
+        }
+
+
+        // 2순위: 사용자의 AccessToken으로 revoke 요청 보내기
+        String enc = user.getRefreshToken();
+        String refresh = encryptor.decrypt(enc);  // 복호화
+        if (refresh != null && !refresh.isBlank()) {
+            OAuthTokenResponse tr = kakaoOAuthService.refreshAccessToken(refresh);
+            kakaoOAuthService.unlinkWithAccessToken(tr.getAccessToken());
+            log.info("Kakao unlink by refreshed access_token 완료");
+        } else {
+            log.info("Kakao refresh_token 없음 -> revoke 생략");
+        }
+    }
 }

--- a/src/main/java/org/example/studylog/service/oauth/ExternalOAuthUnlinkService.java
+++ b/src/main/java/org/example/studylog/service/oauth/ExternalOAuthUnlinkService.java
@@ -1,0 +1,2 @@
+package org.example.studylog.service.oauth;public class ExternalOAuthUnlinkService {
+}

--- a/src/main/java/org/example/studylog/service/oauth/GoogleOAuthService.java
+++ b/src/main/java/org/example/studylog/service/oauth/GoogleOAuthService.java
@@ -1,2 +1,16 @@
-package org.example.studylog.service.oauth;public class GoogleOAuthService {
+package org.example.studylog.service.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studylog.client.GoogleClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthService {
+
+    private final GoogleClient googleClient;
+
+    public void revoke(String token) {
+        googleClient.unlink(token);
+    }
 }

--- a/src/main/java/org/example/studylog/service/oauth/GoogleOAuthService.java
+++ b/src/main/java/org/example/studylog/service/oauth/GoogleOAuthService.java
@@ -1,0 +1,2 @@
+package org.example.studylog.service.oauth;public class GoogleOAuthService {
+}

--- a/src/main/java/org/example/studylog/service/oauth/KakaoOAuthService.java
+++ b/src/main/java/org/example/studylog/service/oauth/KakaoOAuthService.java
@@ -1,0 +1,2 @@
+package org.example.studylog.service.oauth;public class KakaoOAuthService {
+}

--- a/src/main/java/org/example/studylog/service/oauth/KakaoOAuthService.java
+++ b/src/main/java/org/example/studylog/service/oauth/KakaoOAuthService.java
@@ -1,2 +1,64 @@
-package org.example.studylog.service.oauth;public class KakaoOAuthService {
+package org.example.studylog.service.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studylog.client.KakaoApiClient;
+import org.example.studylog.client.KakaoAuthClient;
+import org.example.studylog.dto.oauth.OAuthTokenResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    private final KakaoAuthClient kakaoAuthClient; // https://kauth.kakao.com
+    private final KakaoApiClient kakaoApiClient;   // https://kapi.kakao.com
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret:}")
+    private String clientSecret;
+
+    // Admin Key는 서버 비밀(.env/Parameter Store/KMS 등)로 관리
+    @Value("${kakao.admin-key:}")
+    private String adminKey;
+
+    public boolean hasAdminKey() {
+        return adminKey != null && !adminKey.isBlank();
+    }
+
+    // refresh -> access 재발급
+    public OAuthTokenResponse refreshAccessToken(String refreshToken) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "refresh_token");
+        form.add("client_id", clientId);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            form.add("client_secret", clientSecret);
+        }
+        form.add("refresh_token", refreshToken);
+        return kakaoAuthClient.refreshToken(form);
+    }
+
+    // (사용자 토큰 방식) access_token으로 언링크
+    public void unlinkWithAccessToken(String accessToken) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        kakaoApiClient.unlink("Bearer " + accessToken, form);
+    }
+
+    // (서버 Admin Key 방식) kakao user_id로 언링크
+    public void unlinkWithAdminKey(long kakaoUserId){
+        if (adminKey == null || adminKey.isBlank()){
+            throw new IllegalStateException("Kakao Admin Key is not configured.");
+        }
+
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("target_id_type", "user_id");
+        form.add("target_id", String.valueOf(kakaoUserId));
+
+        kakaoApiClient.unlink("KakaoAK " + adminKey, form);
+
+    }
 }

--- a/src/main/java/org/example/studylog/util/AesGcmEncryptor.java
+++ b/src/main/java/org/example/studylog/util/AesGcmEncryptor.java
@@ -1,0 +1,67 @@
+package org.example.studylog.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class AesGcmEncryptor {
+
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int IV_LEN = 12;     // 96-bit nonce (권장)
+    private static final int TAG_LEN = 128;   // bits
+    private final SecretKeySpec key;
+
+    public AesGcmEncryptor(@Value("${app.crypto.master-key-base64}") String base64Key) {
+        byte[] keyBytes = Base64.getDecoder().decode(base64Key); // 32 bytes(256-bit) 권장
+        this.key = new SecretKeySpec(keyBytes, "AES");
+    }
+
+    public String encrypt(String plaintext) {
+        if (plaintext == null) return null;
+        try {
+            byte[] iv = new byte[IV_LEN];
+            SecureRandom.getInstanceStrong().nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_LEN, iv));
+            byte[] ct = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+
+            ByteBuffer bb = ByteBuffer.allocate(iv.length + ct.length);
+            bb.put(iv).put(ct);
+            // 버전접두어(키 로테이션 대비)
+            return "v1:" + Base64.getUrlEncoder().withoutPadding().encodeToString(bb.array());
+        } catch (Exception e) {
+            throw new IllegalStateException("Encrypt failed", e);
+        }
+    }
+
+    public String decrypt(String ciphertext) {
+        if (ciphertext == null) return null;
+        try {
+            String payload = ciphertext.startsWith("v1:") ? ciphertext.substring(3) : ciphertext;
+            byte[] enc = Base64.getUrlDecoder().decode(payload);
+
+            ByteBuffer bb = ByteBuffer.wrap(enc);
+            byte[] iv = new byte[IV_LEN];
+            bb.get(iv);
+            byte[] ct = new byte[bb.remaining()];
+            bb.get(ct);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_LEN, iv));
+            byte[] pt = cipher.doFinal(ct);
+            return new String(pt, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("Decrypt failed", e);
+        }
+    }
+
+}

--- a/src/main/resources/db/migration/V1__add_column_to_users.sql
+++ b/src/main/resources/db/migration/V1__add_column_to_users.sql
@@ -1,0 +1,3 @@
+-- 인증 서버로부터 받은 refresh_token을 저장할 컬럼 생성
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS refresh_token VARCHAR(1000);


### PR DESCRIPTION
### ✅ 체크 리스트
- [x] 변경 사항에 대한 테스트를 했나요?
- [x] 컨벤션에 맞게 PR 제목과 커밋 메시지를 작성했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
***
### 📌관련 이슈 번호
- closed #39 
***
### 💡작업 내용
- 최초 소셜 로그인 시, 인증 서버로부터 받은 사용자의 RefreshToken 저장
  - User 테이블에 저장 시, 암호화하여 저장 (AES-GCM 암호화 기법)
- 회원 탈퇴 요청 시, 카카오/구글 인증 서버와의 연결을 끊고 사용자의 모든 데이터 삭제 (하드 삭제)
- 구글 연결 해제 전략
   - 사용자의 RefreshToken으로 AccessToken을 재발급 받아 revoke 요청을 보냄
   - AccessToken의 유효기간이 짧으므로 RefreshToken으로 재발급 받는 로직을 추가함
- 카카오 연결 해제 전략 (아래 2가지 방법 모두 구현)
   1. **admin-key** 사용
       - 앱 어드민 키와 사용자의 kakaoUserId로 unlink 요청을 보냄
   2. **AccessToken** 사용
       - 사용자의 RefreshToken으로 AccessToken을 재발급 받아 unlink 요청을 보냄
   - RefreshToken의 만료 가능성이 있어 (1)번 방법을 기본으로 사용 
- Flyway 의존성 및 마이그레이션 파일 추가
   - 현재 운영 DB의 user 테이블에는 `refresh_token` 컬럼이 없는 상태
   - 해당 컬럼을 추가하기 위해 Flyway 마이그레이션 툴을 적용함
***
### 👤 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
***
### 📚참고 문서(선택)


